### PR TITLE
Allow ioki-objects to be used in array types

### DIFF
--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -100,7 +100,7 @@ module Ioki
         when :array
           if value.respond_to?(:map) && model_class
             value.map do |el|
-              model_class.new(el) if el.is_a?(Hash)
+              el.is_a?(Hash) ? model_class.new(el) : el
             end
           else
             Array(value)

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -549,9 +549,26 @@ RSpec.describe Ioki::Model::Base do
           expect(model.type_cast_attribute_value(:attr, nil)).to be_nil
         end
 
-        it 'handles an array correctly' do
+        it 'handles an array of hashes correctly' do
           result = model.type_cast_attribute_value(:attr,
                                                    [{ email: 'mail1@example.com' }, { email: 'mail2@example.com' }])
+          expect(result).to be_kind_of(Array)
+          expect(result.size).to eq(2)
+          expect(result.first).to be_kind_of(Ioki::Model::Platform::User)
+          expect(result.first.email).to eq('mail1@example.com')
+          expect(result.last).to be_kind_of(Ioki::Model::Platform::User)
+          expect(result.last.email).to eq('mail2@example.com')
+        end
+
+        it 'handles an array of fitting objects correctly' do
+          result = model.type_cast_attribute_value(
+            :attr,
+            [
+              Ioki::Model::Platform::User.new(email: 'mail1@example.com'),
+              Ioki::Model::Platform::User.new(email: 'mail2@example.com')
+            ]
+          )
+
           expect(result).to be_kind_of(Array)
           expect(result.size).to eq(2)
           expect(result.first).to be_kind_of(Ioki::Model::Platform::User)


### PR DESCRIPTION
instead of requiring a hash. Similar to type :object.