### PR TITLE
Less defaults for Ioki::Configuration.new

### DIFF
--- a/spec/helper/client_helpers.rb
+++ b/spec/helper/client_helpers.rb
@@ -2,31 +2,21 @@
 
 module ExtendedClientHelpers
   def setup_platform_client(client_name)
-    let(client_name) { build_platform_client }
+    let(client_name) { build_platform_client_from_envs }
   end
 
   def setup_passenger_client(client_name)
-    let(client_name) { build_passenger_client }
+    let(client_name) { build_passenger_client_from_envs }
   end
 
   def setup_driver_client(client_name)
-    let(client_name) { build_driver_client }
+    let(client_name) { build_driver_client_from_envs }
   end
 end
 
 module IncludedClientHelpers
-  def build_platform_client
-    Ioki::Client.new(
-      Ioki::Configuration.new(
-        api_base_url:          ENV['IOKI_PLATFORM_API_BASE_URL'],
-        api_version:           ENV['IOKI_PLATFORM_API_VERSION'],
-        api_client_identifier: ENV['IOKI_PLATFORM_API_CLIENT_IDENTIFIER'],
-        api_client_secret:     ENV['IOKI_PLATFORM_API_CLIENT_SECRET'],
-        api_client_version:    ENV['IOKI_PLATFORM_API_CLIENT_VERSION'],
-        api_token:             ENV['IOKI_PLATFORM_API_TOKEN']
-      ),
-      Ioki::PlatformApi
-    )
+  def build_platform_client_from_envs
+    Ioki::Client.new(Ioki::Configuration.from_env('PLATFORM'), Ioki::PlatformApi)
   end
 
   def with_platform_client(&block)
@@ -34,18 +24,8 @@ module IncludedClientHelpers
     block.call(platform_client)
   end
 
-  def build_passenger_client
-    Ioki::Client.new(
-      Ioki::Configuration.new(
-        api_base_url:          ENV['IOKI_PASSENGER_API_BASE_URL'],
-        api_version:           ENV['IOKI_PASSENGER_API_VERSION'],
-        api_client_identifier: ENV['IOKI_PASSENGER_API_CLIENT_IDENTIFIER'],
-        api_client_secret:     ENV['IOKI_PASSENGER_API_CLIENT_SECRET'],
-        api_client_version:    ENV['IOKI_PASSENGER_API_CLIENT_VERSION'],
-        api_token:             ENV['IOKI_PASSENGER_API_TOKEN']
-      ),
-      Ioki::PassengerApi
-    )
+  def build_passenger_client_from_envs
+    Ioki::Client.new(Ioki::Configuration.from_env('PASSENGER'), Ioki::PassengerApi)
   end
 
   def with_passenger_client(&block)
@@ -53,18 +33,8 @@ module IncludedClientHelpers
     block.call(passenger_client)
   end
 
-  def build_driver_client
-    Ioki::Client.new(
-      Ioki::Configuration.new(
-        api_base_url:          ENV['IOKI_DRIVER_API_BASE_URL'],
-        api_version:           ENV['IOKI_DRIVER_API_VERSION'],
-        api_client_identifier: ENV['IOKI_DRIVER_API_CLIENT_IDENTIFIER'],
-        api_client_secret:     ENV['IOKI_DRIVER_API_CLIENT_SECRET'],
-        api_client_version:    ENV['IOKI_DRIVER_API_CLIENT_VERSION'],
-        api_token:             ENV['IOKI_DRIVER_API_TOKEN']
-      ),
-      Ioki::DriverApi
-    )
+  def build_driver_client_from_envs
+    Ioki::Client.new(Ioki::Configuration.from_env('DRIVER'), Ioki::DriverApi)
   end
 
   def with_driver_client(&block)


### PR DESCRIPTION
These were the guiding principles for the refactoring. Based on previous discussions with @ans-ioki:

1. A new config should be as comfortable as possible to create in the console -> `Ioki::Configuration.from_env`
1. Each attribute of the config should be changeable by `client.config.attribute = setting`
1. config.reset! should read env-variables to allow changing during a console-development workflow
1. The VCR specs have to be able to read from env so they can send real requests.
1. The config should not know about multiple environments, because future developers will be expected to only work with one API.
1. Don't read from envs per default and be as explicit as possible to ease tracing of values to their origin.

The most important change for me is probably not reading from env per default.