### PR TITLE
Use type attribute for Platform::Area

### DIFF
--- a/lib/ioki/model/platform/area.rb
+++ b/lib/ioki/model/platform/area.rb
@@ -3,8 +3,9 @@
 module Ioki
   module Model
     module Platform
-      class Area < Base
+      class Area < Ioki::Model::Base
         attribute :coordinates, type: :array, on: :read
+        attribute :type, type: :string, on: :read
       end
     end
   end


### PR DESCRIPTION
Note that we need to inherit from `Ioki::Model::Base` instead of `Ioki::Model::Platform::Base` because the latter already defines `type`.