### PR TITLE
Refactor url_elements

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -32,7 +32,7 @@ module Endpoints
       end
 
       parsed_response, response = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(name, full_path, *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(full_path, *args)),
         method:  :post,
         body:    { data: model.serialize(:create) }.to_json,
         headers: client.all_headers,

--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -25,7 +25,7 @@ module Endpoints
 
     def call(client, args = [], options = {})
       parsed_response, = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(name, full_path, *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(full_path, *args)),
         method:  :delete,
         headers: client.all_headers,
         params:  options[:params]

--- a/lib/ioki/apis/endpoints/endpoint.rb
+++ b/lib/ioki/apis/endpoints/endpoint.rb
@@ -18,7 +18,7 @@ module Endpoints
 
     def call(client, args = [], options = {})
       parsed_response, = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(resource, path + [action], *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(path + [action], *args)),
         method:  request_method,
         headers: client.all_headers,
         body:    options[:body].to_json,

--- a/lib/ioki/apis/endpoints/index.rb
+++ b/lib/ioki/apis/endpoints/index.rb
@@ -47,7 +47,7 @@ module Endpoints
 
     def send_request(client, args, options)
       parsed_response, = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(name, full_path, *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(full_path, *args)),
         headers: client.all_headers,
         params:  options[:params]
       )

--- a/lib/ioki/apis/endpoints/show.rb
+++ b/lib/ioki/apis/endpoints/show.rb
@@ -34,7 +34,7 @@ module Endpoints
 
     def model_params(client, args, options, model)
       parsed_response, response = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(name, full_path, *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(full_path, *args)),
         headers: client.all_headers(etag: model&._etag),
         params:  options[:params]
       )

--- a/lib/ioki/apis/endpoints/update.rb
+++ b/lib/ioki/apis/endpoints/update.rb
@@ -32,7 +32,7 @@ module Endpoints
       end
 
       parsed_response, response = client.request(
-        url:     client.build_request_url(*Endpoints.url_elements(name, full_path, *args)),
+        url:     client.build_request_url(*Endpoints.url_elements(full_path, *args)),
         method:  :patch,
         body:    { data: model.serialize(:update) }.to_json,
         headers: client.all_headers,

--- a/spec/ioki/apis/endpoints/endpoints_spec.rb
+++ b/spec/ioki/apis/endpoints/endpoints_spec.rb
@@ -3,33 +3,36 @@
 RSpec.describe Endpoints do
   describe '.url_elements' do
     it 'creates a concrete path from one with placeholders and corresponding string args' do
-      expect(described_class.url_elements('platform', [:id], 'RIDE_ID')).
-        to eq ['RIDE_ID']
+      expect(described_class.url_elements([:id], 'RIDE_ID')).to eq ['RIDE_ID']
     end
 
     it 'keeps path fragments that are not meant to be interpolated' do
-      expect(described_class.url_elements('platform', ['ride', :id], 'RIDE_ID')).
-        to eq %w[ride RIDE_ID]
+      expect(described_class.url_elements(['ride', :id], 'RIDE_ID')).to eq %w[ride RIDE_ID]
     end
 
     it 'calls the interpolation method on the given arguments' do
       expect(
-        described_class.url_elements(
-          'platform',
-          ['ride', :id],
-          instance_double(Ioki::Model::Platform::Ride, 'ride', id: 'RIDE_ID')
-        )
+        described_class.url_elements(['ride', :id], instance_double(Ioki::Model::Platform::Ride, 'ride', id: 'RIDE_ID'))
       ).to eq %w[ride RIDE_ID]
     end
 
     it 'raises an error if the argument does not respond_to the interpolation method' do
-      expect do
-        described_class.url_elements(
-          'platform',
-          [:id],
-          instance_double(Ioki::Model::Platform::RidePassenger, 'non_id_object')
-        )
-      end.to raise_error(ArgumentError, "#'platform': argument 1 must respond to :id or to be a string")
+      expect { described_class.url_elements([:id], 1) }.
+        to raise_error(NoMethodError, /undefined method `id' for 1:Integer/)
+    end
+
+    it 'raises an error if the path consists of something else than Strings and Symbols' do
+      expect { described_class.url_elements([1], 'RIDE_ID') }.
+        to raise_error(ArgumentError, 'path: must consist of Strings and Symbols only')
+    end
+
+    context 'with more interpolation variables in the path than given arguments' do
+      let(:path) { [:id, :ride_id] }
+
+      it 'raises an argument error' do
+        expect { described_class.url_elements(path, 'RIDE_ID') }.
+          to raise_error(ArgumentError, 'args: must have an argument for every symbol in :path')
+      end
     end
   end
 end


### PR DESCRIPTION
Also simplifies error handling by relying on ruby's existing error and
removing an unnecessary argument which was only used for an error
message. The information is still there for debugging because in the
backtrace, because we introduced more classes.