### PR TITLE
Don't require version on ride creation

### DIFF
--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -21,7 +21,6 @@ model_class: Ioki::Model::Passenger::RequestedPoint
         attribute :passengers,     type: :array,   on: [:create, :read],
 model_class: Ioki::Model::Passenger::RidePassenger
         attribute :user,           type: :object,  on: :read, model_class: Ioki::Model::Passenger::User
-        attribute :version,        type: :integer, on: [:read, :create, :update]
         attribute :booking,        type: :object,  on: :read, model_class: Ioki::Model::Passenger::Booking
         attribute :pickup,         type: :object,  on: :read, model_class: Ioki::Model::Passenger::CalculatedPoint
         attribute :dropoff,        type: :object,  on: :read, model_class: Ioki::Model::Passenger::CalculatedPoint

--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -53,7 +53,7 @@ model_class: Ioki::Model::Passenger::CalculatedPoint
         attribute :vehicle, type: :object, model_class: Ioki::Model::Passenger::Vehicle, on: [:read, :create, :update]
         attribute :vehicle_reached_dropoff, type: :boolean, on: [:read, :create, :update]
         attribute :vehicle_reached_pickup, type: :boolean, on: [:read, :create, :update]
-        attribute :version, type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create]
+        attribute :version, type: :integer, on: [:read, :update]
       end
     end
   end

--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -53,7 +53,7 @@ model_class: Ioki::Model::Passenger::CalculatedPoint
         attribute :vehicle, type: :object, model_class: Ioki::Model::Passenger::Vehicle, on: [:read, :create, :update]
         attribute :vehicle_reached_dropoff, type: :boolean, on: [:read, :create, :update]
         attribute :vehicle_reached_pickup, type: :boolean, on: [:read, :create, :update]
-        attribute :version, type: :integer, on: [:read, :create, :update]
+        attribute :version, type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create]
       end
     end
   end

--- a/lib/ioki/model/platform/ride.rb
+++ b/lib/ioki/model/platform/ride.rb
@@ -26,7 +26,7 @@ model_class: Ioki::Model::Platform::RidePassenger
         attribute :dropoff,        type: :object,  on: :read, model_class: Ioki::Model::Platform::CalculatedPoint
         attribute :storage_spaces, type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
         attribute :rating,         type: :object,  on: :read, model_class: Ioki::Model::Platform::Rating
-        attribute :version,        type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create]
+        attribute :version,        type: :integer, on: [:read, :update]
       end
     end
   end

--- a/lib/ioki/model/platform/ride.rb
+++ b/lib/ioki/model/platform/ride.rb
@@ -21,12 +21,12 @@ model_class: Ioki::Model::Platform::RidePassenger
         attribute :user_id,        type: :string,  on: [:create, :update]
         attribute :product_id,     type: :string,  on: [:read, :create, :update]
         attribute :user,           type: :object,  on: :read, model_class: Ioki::Model::Platform::User
-        attribute :version,        type: :string,  on: :update
         attribute :booking,        type: :object,  on: :read, model_class: Ioki::Model::Platform::Booking
         attribute :pickup,         type: :object,  on: :read, model_class: Ioki::Model::Platform::CalculatedPoint
         attribute :dropoff,        type: :object,  on: :read, model_class: Ioki::Model::Platform::CalculatedPoint
         attribute :storage_spaces, type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
         attribute :rating,         type: :object,  on: :read, model_class: Ioki::Model::Platform::Rating
+        attribute :version,        type: :integer, on: [:read, :create, :update], omit_if_blank_on: [:create]
       end
     end
   end

--- a/spec/ioki/examples/create_book_and_confirm_with_platform_spec.rb
+++ b/spec/ioki/examples/create_book_and_confirm_with_platform_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe 'Create, book and confirm a ride with the platform API', :vcr do
 
     # The booking was confirmed:
     expect(confirmed_ride.state).to eq 'driver_accepted'
+    expect(confirmed_ride.version).to eq 6
     expect(booked_ride.booking.verification_code).not_to be_empty
 
     # Pickup information is available:


### PR DESCRIPTION
Also removes accidental double definition of type on passenger ride.