### PR TITLE
Fix version being required on create for rides

### DIFF
--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -9,7 +9,6 @@ module Ioki
         attribute :destination, type: :object, on: [:create, :read], class_name: 'RequestedPoint'
         attribute :passengers, type: :array, on: [:create, :read], class_name: 'RidePassenger'
         attribute :user, type: :object, on: :read, class_name: 'User'
-        attribute :version, type: :integer, on: [:read, :create, :update]
         attribute :booking, type: :object, on: :read, class_name: 'Booking'
         attribute :pickup, type: :object, on: :read, class_name: 'CalculatedPoint'
         attribute :dropoff, type: :object, on: :read, class_name: 'CalculatedPoint'

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -92,6 +92,7 @@ RSpec.describe Ioki::PassengerApi do
     it 'calls request on the client with expected params' do
       expect(passenger_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('passenger/rides')
+        expect(params[:body][:data]).not_to have_key(:version)
         [result_with_data, full_response]
       end
 


### PR DESCRIPTION
This was accidentally introduced in #54 and prevented us from creating
rides, since they don't have a version then as they are just about to be
created.

In the long run, we might wanna sort those attributes alphabetically, so that these kind of double definitions are easier to spot.