### PR TITLE
Make Ioki::Model::Platform::ServiceCredit #charges attribute an array

### DIFF
--- a/lib/ioki/model/platform/service_credit.rb
+++ b/lib/ioki/model/platform/service_credit.rb
@@ -7,7 +7,7 @@ module Ioki
         attribute :admin, on: :read, type: :object, class_name: 'Admin'
         attribute :balance, on: :read, type: :object, class_name: 'Money'
         attribute :channel, on: :read, type: :string
-        attribute :charges, on: :read, type: :object, class_name: 'ServiceCreditCharge'
+        attribute :charges, on: :read, type: :array, class_name: 'ServiceCreditCharge'
         attribute :consumed, on: :read, type: :boolean
         attribute :cost, on: :read, type: :object, class_name: 'Money'
         attribute :payment_method, on: :read, type: :object, class_name: 'PaymentMethod'

--- a/spec/ioki/model/platform/service_credit_spec.rb
+++ b/spec/ioki/model/platform/service_credit_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Platform::ServiceCredit do
+  subject(:service_credit) do
+    described_class.new(
+      id:      'scr_1',
+      admin:   { id: 'adm_1' },
+      charges: [{ id: 'scc_1' }, { id: 'scc_2' }]
+    )
+  end
+
+  describe '#admin attribute' do
+    it 'is an Ioki::Model::Platform::Admin' do
+      expect(service_credit.admin).to be_a(Ioki::Model::Platform::Admin)
+    end
+  end
+
+  describe '#charges attribute' do
+    it 'is an array' do
+      expect(service_credit.charges).to be_a(Array)
+    end
+
+    it 'contains 2 entries' do
+      expect(service_credit.charges.count).to eq(2)
+    end
+
+    it 'consists of two Ioki::Model::Platform::ServiceCreditCharge objects' do
+      expect(service_credit.charges[0]).to be_a(Ioki::Model::Platform::ServiceCreditCharge)
+      expect(service_credit.charges[1]).to be_a(Ioki::Model::Platform::ServiceCreditCharge)
+    end
+  end
+end


### PR DESCRIPTION
The platform API defines the Ioki::Model::Platform::ServiceCredit charges attribute as a `"type": "array"`, but here it is defined as an object. 

