### PR TITLE
Enables iterating over index endpoint results in a given block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Basic usage of a `Ioki::Client`
   products = platform_client.products
   # returns a list of Ioki::Model::Platform::Product instances
 
-  stations = platform_client.stations(products.first, options: { auto_paginate: true })
+  stations = platform_client.stations(products.first, auto_paginate: true)
   # stations are a scoped endpoint within products, to the interface requires
   # either a product or a product id as the first parameter.
   # This call will then fetch the index of stations. This example also shows

--- a/lib/ioki/client.rb
+++ b/lib/ioki/client.rb
@@ -12,7 +12,7 @@ module Ioki
       @config = config
 
       api::ENDPOINTS.flatten.compact.each do |endpoint|
-        define_singleton_method(endpoint.name) do |*args|
+        define_singleton_method(endpoint.name) do |*args, &block|
           # Each method defined by the API takes `args` matching the symbols in an enpoint's path, while the last
           # parameter is an optional options hash. The last argument that's not the options hash is also the required
           # model for Update and Create enpoints.
@@ -27,6 +27,8 @@ module Ioki
 
           if [Endpoints::Create, Endpoints::Update].include?(endpoint.class)
             endpoint.call(self, model, args, options)
+          elsif endpoint.is_a? Endpoints::Index
+            endpoint.call(self, args, options, &block)
           else
             endpoint.call(self, args, options)
           end

--- a/spec/ioki/apis/endpoints/index_spec.rb
+++ b/spec/ioki/apis/endpoints/index_spec.rb
@@ -13,69 +13,92 @@ RSpec.describe Endpoints::Index do
   let(:parsed_response) { instance_double(Hash, 'parsed_response', :[] => [], dig: {}) }
   let(:full_response) { instance_double(Faraday::Response, 'full_response') }
   let(:endpoint)  { described_class.new('product', base_path: ['base'], model_class: model_class) }
-  let(:params)    { instance_double(Hash, 'params') }
+  let(:params)    { { per_page: 2 } }
 
-  it 'calls #request on the client instantiating classes from the result' do
-    expect(client).to receive(:request).
-      with(hash_including(
-             url:    url,
-             params: params
-           )).and_return(
-             { 'data' => [{ 'id' => '0815' }, { 'id' => '4711' }] }
-           )
-
-    result = endpoint.call(client, [], model_class: model_class, params: params)
-
-    expect(result).to be_kind_of(Array)
-    expect(result.size).to eq(2)
-
-    expect(result.first).to be_kind_of(model_class)
-    expect(result.first.id).to eq('0815')
-
-    expect(result.last).to be_kind_of(model_class)
-    expect(result.last.id).to eq('4711')
-  end
-
-  it 'provides a way to auto_paginate all elements' do
-    call_number = 0
-
+  before 'stub client.request' do
     allow(client).to receive(:request) do |params|
-      call_number += 1
-
-      case call_number
-      when 1
-        expect(params[:params].to_s).to eq('{:per_page=>2, :page=>1}')
+      case params.dig(:params, :page)
+      when nil, 1
         { 'data' => [{ 'id' => '001' }, { 'id' => '002' }], 'meta' => { 'page' => 1, 'last_page' => false } }
       when 2
-        expect(params[:params].to_s).to eq('{:per_page=>2, :page=>2}')
         { 'data' => [{ 'id' => '003' }, { 'id' => '004' }], 'meta' => { 'page' => 2, 'last_page' => false } }
       when 3
-        expect(params[:params].to_s).to eq('{:per_page=>2, :page=>3}')
         { 'data' => [{ 'id' => '005' }], 'meta' => { 'page' => 3, 'last_page' => true } }
       else
         raise 'unexpected call'
       end
     end
+  end
 
-    result = endpoint.call(
-      client,
-      [],
-      model_class:   model_class,
-      params:        { per_page: 2 },
-      auto_paginate: true
+  it 'calls #request on the client' do
+    expect(client).to receive(:request).with(hash_including(url: url, params: params)).and_return('data' => [])
+    endpoint.call client, [], model_class: model_class, params: params
+  end
+
+  it 'returns a two element Array' do
+    result = endpoint.call client, [], model_class: model_class, params: params
+
+    expect(result).to be_kind_of(Array)
+    expect(result.size).to eq(2)
+  end
+
+  it 'returns an Array of the correct model_class' do
+    result = endpoint.call client, [], model_class: model_class, params: params
+
+    expect(result.first).to be_kind_of(model_class)
+    expect(result.last).to be_kind_of(model_class)
+  end
+
+  it 'returns an Array with the correct attributes' do
+    result = endpoint.call client, [], model_class: model_class, params: params
+
+    expect(result.first.id).to eq('001')
+    expect(result.last.id).to eq('002')
+  end
+
+  it 'yields 2 times to the given block' do
+    expect do |block|
+      endpoint.call client, [], model_class: model_class, params: params, &block
+    end.to yield_control.exactly(2).times
+  end
+
+  it 'yields each model to the given block with the correct model' do
+    expect do |block|
+      endpoint.call client, [], model_class: model_class, params: params, &block
+    end.to yield_successive_args(
+      have_attributes('id' => '001'),
+      have_attributes('id' => '002')
     )
+  end
+
+  it 'provides a way to auto_paginate all elements' do
+    result = endpoint.call client, [], model_class: model_class, params: params, auto_paginate: true
 
     expect(result).to be_kind_of(Array)
     expect(result.size).to eq(5)
     expect(result.map(&:id)).to eq(%w[001 002 003 004 005])
   end
 
-  it 'works without an explicit params hash' do
-    expect(client).
-      to receive(:request).
-      with(params: { page: 1 }, url: url).
-      and_return('data' => [{ 'id' => '4711' }])
+  it 'yields 5 times to the given block using auto_paginate' do
+    expect do |block|
+      endpoint.call client, [], model_class: model_class, params: params, auto_paginate: true, &block
+    end.to yield_control.exactly(5).times
+  end
 
+  it 'yields each model to the given block with the correct model using auto_paginate' do
+    expect do |block|
+      endpoint.call client, [], model_class: model_class, params: params, auto_paginate: true, &block
+    end.to yield_successive_args(
+      have_attributes('id' => '001'),
+      have_attributes('id' => '002'),
+      have_attributes('id' => '003'),
+      have_attributes('id' => '004'),
+      have_attributes('id' => '005')
+    )
+  end
+
+  it 'works without an explicit params hash' do
+    expect(client).to receive(:request).with(params: { page: 1 }, url: url).and_return('data' => [])
     endpoint.call(client, [], model_class: model_class, auto_paginate: true)
   end
 end


### PR DESCRIPTION
In stead of creating a very large array I would prefer to iterate over the results directly. 