### PR TITLE
Fix missing version on PATCH passenger/user

### DIFF
--- a/lib/ioki/model/passenger/user.rb
+++ b/lib/ioki/model/passenger/user.rb
@@ -22,7 +22,7 @@ module Ioki
         attribute :registered, on: :read, type: :boolean
         attribute :remaining_referrals, on: :read, type: :integer
         attribute :unique_customer_id, on: :read, type: :string
-        attribute :version, on: :read, type: :integer
+        attribute :version, on: [:read, :update], type: :integer
       end
     end
   end


### PR DESCRIPTION
It seems that the `version` is missing when calling `update_user` in the passenger API.

If the API is called as in the following:

```ruby
    api_user = Ioki::Model::Passenger::User.new(
      first_name: 'Sarah',
      last_name: 'Musterfrau',
      email: Ioki::Model::Passenger::Email.new(email_address: nil),
      version: 0
    )

    passenger_client.update_user(api_user)
```

Body sent to the API:

```
{:data=>
  {:email=>{:email_address=>nil},
   :first_name=>"Sarah",
   :last_name=>"Musterfrau"}}
```

`version` is missing in the body and the API complains accordingly:

```
{"api_errors"=>[{"message"=>"Version missing", "code"=>"version_missing"}],
 "debug_information"=>[]
```