### PR TITLE
Fix missing version attribute when updating user

### DIFF
--- a/lib/ioki/model/platform/user.rb
+++ b/lib/ioki/model/platform/user.rb
@@ -21,7 +21,7 @@ omit_if_blank_on: [:create, :update]
         attribute :terms_accepted_at, type: :date_time, on: :read
         # The model does not return it but it's used when sending data to the server.
         attribute :terms_accepted,    type: :boolean, on: [:create, :update], unvalidated: true
-        attribute :version,           type: :integer, on: :read
+        attribute :version,           type: :integer, on: [:read, :update]
       end
     end
   end


### PR DESCRIPTION
This is the same as #58, but for the platform API (instead of the passenger API).