### PR TITLE
Change serializers to allow `Rating` to be created

### DIFF
--- a/lib/ioki/model/passenger/rating.rb
+++ b/lib/ioki/model/passenger/rating.rb
@@ -5,14 +5,15 @@ module Ioki
     module Passenger
       class Rating < Base
         attribute :version, on: :read, type: :integer
-        attribute :comment, on: :read, type: :string
-        attribute :driver_rating, on: :read, type: :integer
+        attribute :comment, on: [:read, :create], type: :string
+        attribute :driver_rating, on: [:read, :create], type: :integer
         attribute :editable, on: :read, type: :boolean
-        attribute :punctuality_rating, on: :read, type: :integer
-        attribute :ride_rating, on: :read, type: :integer
-        attribute :service_rating, on: :read, type: :integer
-        attribute :vehicle_rating, on: :read, type: :integer
-        attribute :waiting_time_rating, on: :read, type: :integer
+        attribute :punctuality_rating, on: [:read, :create], type: :integer
+        attribute :ride_rating, on: [:read, :create], type: :integer
+        attribute :service_rating, on: [:read, :create], type: :integer
+        attribute :vehicle_rating, on: [:read, :create], type: :integer
+        attribute :waiting_time_rating, on: [:read, :create], type: :integer
+        attribute :ride_version, on: :create, type: :integer
       end
     end
   end

--- a/lib/ioki/model/platform/rating.rb
+++ b/lib/ioki/model/platform/rating.rb
@@ -5,14 +5,15 @@ module Ioki
     module Platform
       class Rating < Base
         attribute :version, on: :read, type: :integer
-        attribute :vehicle_rating, on: :read, type: :integer
-        attribute :service_rating, on: :read, type: :integer
-        attribute :driver_rating, on: :read, type: :integer
-        attribute :ride_rating, on: :read, type: :integer
-        attribute :waiting_time_rating, on: :read, type: :integer
-        attribute :punctuality_rating, on: :read, type: :integer
-        attribute :comment, on: :read, type: :string
+        attribute :vehicle_rating, on: [:read, :create], type: :integer
+        attribute :service_rating, on: [:read, :create], type: :integer
+        attribute :driver_rating, on: [:read, :create], type: :integer
+        attribute :ride_rating, on: [:read, :create], type: :integer
+        attribute :waiting_time_rating, on: [:read, :create], type: :integer
+        attribute :punctuality_rating, on: [:read, :create], type: :integer
+        attribute :comment, on: [:read, :create], type: :string
         attribute :editable, on: :read, type: :boolean
+        attribute :ride_version, on: :create, type: :integer
       end
     end
   end


### PR DESCRIPTION
Allows creating `Rating`s on the platform API as well as the passenger API.