### PR TITLE
Add additional_information_url to announcements

### DIFF
--- a/lib/ioki/model/passenger/announcement.rb
+++ b/lib/ioki/model/passenger/announcement.rb
@@ -4,6 +4,7 @@ module Ioki
   module Model
     module Passenger
       class Announcement < Base
+        attribute :additional_information_url, on: :read, type: :string
         attribute :ends_at, on: :read, type: :date_time
         attribute :severity, on: :read, type: :string
         attribute :show_on_every_app_start, on: :read, type: :boolean

--- a/lib/ioki/model/platform/announcement.rb
+++ b/lib/ioki/model/platform/announcement.rb
@@ -4,6 +4,7 @@ module Ioki
   module Model
     module Platform
       class Announcement < Base
+        attribute :additional_information_url, on: :read, type: :string
         attribute :ends_at, on: :read, type: :date_time
         attribute :severity, on: :read, type: :string
         attribute :show_on_every_app_start, on: :read, type: :boolean


### PR DESCRIPTION
Adds additional_information_url to announcements, which is an attribute I've overlooked in #68 