### PR TITLE
Adds :provider_id to Ioki::Model::Platform::User model 

### DIFF
--- a/lib/ioki/model/platform/user.rb
+++ b/lib/ioki/model/platform/user.rb
@@ -4,24 +4,24 @@ module Ioki
   module Model
     module Platform
       class User < Base
-        attribute :email,             type: :object,  on: [:read, :create, :update],
-omit_if_blank_on: [:create, :update], class_name: 'UserEmail'
-        attribute :external_id,       type: :string,  on: [:read, :create, :update],
-omit_if_blank_on: [:create, :update]
-        attribute :first_name,        type: :string,  on: [:read, :create, :update],
-omit_if_blank_on: [:create, :update]
-        attribute :last_name,         type: :string,  on: [:read, :create, :update],
-omit_if_blank_on: [:create, :update]
-        attribute :locale,            type: :string,  on: :read
-        attribute :lock_reason,       type: :string,  on: :read
-        attribute :lock_type,         type: :string,  on: :read
-        attribute :locked_at,         type: :date_time, on: :read
-        attribute :phone_number,      type: :string, on: [:read, :create, :update],
-omit_if_blank_on: [:create, :update]
+        attribute :email,
+                  type:             :object,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  class_name:       'UserEmail'
+        attribute :external_id, type: :string, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
+        attribute :first_name, type: :string, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
+        attribute :last_name, type: :string, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
+        attribute :locale, type: :string, on: :read
+        attribute :lock_reason, type: :string, on: :read
+        attribute :lock_type, type: :string, on: :read
+        attribute :locked_at, type: :date_time, on: :read
+        attribute :phone_number, type: :string, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
+        attribute :provider_id, type: :string, on: :read
         attribute :terms_accepted_at, type: :date_time, on: :read
         # The model does not return it but it's used when sending data to the server.
-        attribute :terms_accepted,    type: :boolean, on: [:create, :update], unvalidated: true
-        attribute :version,           type: :integer, on: [:read, :update]
+        attribute :terms_accepted, type: :boolean, on: [:create, :update], unvalidated: true
+        attribute :version, type: :integer, on: [:read, :update]
       end
     end
   end

--- a/spec/helper/define_attribute_matcher.rb
+++ b/spec/helper/define_attribute_matcher.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+# Usage:
+#
+# RSpec.describe Ioki::Model::Platform::User do
+#   it { is_expected.to define_attribute(:id) }
+#   it { is_expected.to define_attribute(:external_id).as(:string) }
+#   it { is_expected.to define_attribute(:email).as(:object).with(class_name: 'UserEmail') }
+# end
+
+RSpec::Matchers.define :define_attribute do |expected_attribute_name|
+  match do |actual_model|
+    attribute_definitions = actual_model.class.attribute_definitions
+    attribute_definitions.key?(expected_attribute_name) &&
+      (
+        @expected_attribute_type.nil? ||
+        attribute_definitions[expected_attribute_name][:type] == @expected_attribute_type
+      ) &&
+      (
+        @expected_hash.nil? || @expected_hash.all? do |key, value|
+          attribute_definitions[expected_attribute_name][key] == value
+        end
+      )
+  end
+
+  chain :as do |expected_attribute_type|
+    @expected_attribute_type = expected_attribute_type
+  end
+
+  chain :with do |expected_hash|
+    @expected_hash = expected_hash
+  end
+
+  description do |_actual_model|
+    "define :#{expected_attribute_name}" \
+      + (@expected_attribute_type.nil? ? '' : " as a :#{@expected_attribute_type}") \
+      + (@expected_hash.nil? ? '' : " with options '#{@expected_hash}'")
+  end
+
+  failure_message do |_actual_model|
+    "does not define :#{expected_attribute_name}" \
+      + (@expected_attribute_type.nil? ? '' : " as a :#{@expected_attribute_type}") \
+      + (@expected_hash.nil? ? '' : " with options '#{@expected_hash}'")
+  end
+end

--- a/spec/ioki/model/platform/user_spec.rb
+++ b/spec/ioki/model/platform/user_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Platform::User do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+
+  it { is_expected.to define_attribute(:email).as(:object).with(class_name: 'UserEmail') }
+  it { is_expected.to define_attribute(:external_id).as(:string) }
+  it { is_expected.to define_attribute(:first_name).as(:string) }
+  it { is_expected.to define_attribute(:last_name).as(:string) }
+  it { is_expected.to define_attribute(:locale).as(:string) }
+  it { is_expected.to define_attribute(:lock_reason).as(:string) }
+  it { is_expected.to define_attribute(:lock_type).as(:string) }
+  it { is_expected.to define_attribute(:locked_at).as(:date_time) }
+  it { is_expected.to define_attribute(:phone_number).as(:string) }
+  it { is_expected.to define_attribute(:provider_id).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:terms_accepted_at).as(:date_time) }
+  it { is_expected.to define_attribute(:terms_accepted).as(:boolean) }
+  it { is_expected.to define_attribute(:version).as(:integer) }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ require 'webmock/rspec'
 require 'helper/string_helper'
 require 'helper/client_helpers'
 require 'helper/openapi_matcher'
+require 'helper/define_attribute_matcher'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The Platform API has thankfully added the `:provider_id` attribute to the `platform_api--v20210101--user` definition. This PR adds it to the Ioki::Model::Platform::User model.

Additionally this PR adds unit tests for this model, for which a custom matcher has been implemented.