### PR TITLE
Allow email to be provided when creating user

### DIFF
--- a/lib/ioki/model/platform/user_email.rb
+++ b/lib/ioki/model/platform/user_email.rb
@@ -10,9 +10,9 @@ module Ioki
         unvalidated true
 
         attribute :confirmed,     on: :read, type: :boolean
-        attribute :email_address, on: [:read, :update], type: :string
-        attribute :newsletter,    on: [:read, :update], type: :boolean
-        attribute :receipt,       on: [:read, :update], type: :boolean
+        attribute :email_address, on: [:create, :read, :update], type: :string
+        attribute :newsletter,    on: [:create, :read, :update], type: :boolean
+        attribute :receipt,       on: [:create, :read, :update], type: :boolean
       end
     end
   end

--- a/spec/ioki/model/platform/user_email_spec.rb
+++ b/spec/ioki/model/platform/user_email_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Platform::UserEmail do
+  it { is_expected.to define_attribute(:email_address).as(:string) }
+  it { is_expected.to define_attribute(:newsletter).as(:boolean) }
+  it { is_expected.to define_attribute(:receipt).as(:boolean) }
+end


### PR DESCRIPTION
Allows email-only users to be created. For that we need to be able to provide the email address `on: :create`.