### PR TITLE
Fix naming in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI for all of schalter
+name: CI for all of ioki-ruby
 
 on: [push]
 


### PR DESCRIPTION
This PR fixes the naming in the `ci.yml` file from `CI for all of schalter` to `CI for all of ioki-ruby`.