### PR TITLE
Don't send nil headers

### DIFF
--- a/lib/ioki/http_adapter.rb
+++ b/lib/ioki/http_adapter.rb
@@ -41,7 +41,7 @@ module Ioki
         'X-Client-Identifier' => config.api_client_identifier,
         'X-Client-Secret'     => config.api_client_secret,
         'X-Client-Version'    => config.api_client_version
-      }
+      }.compact { |_key, value| !value.nil? }
     end
   end
 end

--- a/spec/ioki/http_adapter_spec.rb
+++ b/spec/ioki/http_adapter_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe Ioki::HttpAdapter do
     it { is_expected.to include 'X-Client-Secret'     => config.api_client_secret }
     it { is_expected.to include 'X-Client-Version'    => config.api_client_version }
     it { is_expected.to include 'Authorization'       => "Bearer #{config.api_token}" }
+
+    context 'when there is a header without a value' do
+      before do
+        config.api_client_identifier = nil
+      end
+
+      it { is_expected.not_to include 'X-Client-Identifier' }
+    end
   end
 
   describe 'logger' do


### PR DESCRIPTION
We currently send the string `nil` as a header value for headers without a value. Upon request of @ans-ioki, we now don't send those headers at all.