### PR TITLE
Operator API | Add station endpoints and model

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -38,6 +38,17 @@ module Ioki
         :place,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::Place
+      ),
+      Endpoints.crud_endpoints(
+        :station,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::Station
+      ),
+      Endpoints.custom_endpoints(
+        'stations',
+        actions:     { 'fix' => :patch, 'unfix' => :patch },
+        path:        [API_BASE_PATH, 'products', :id, 'stations', :id],
+        model_class: Ioki::Model::Operator::Station
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -4,25 +4,116 @@ module Ioki
   module Model
     module Operator
       class Station < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :station_type,  on: [:read, :create, :update], type: :string
-        attribute :location_name, on: [:read, :create, :update], type: :string
-        attribute :lat,           on: [:read, :create, :update], type: :float
-        attribute :lng,           on: [:read, :create, :update], type: :float
-        attribute :city,          on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :country,       on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :county,        on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :description,   on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :external_id,   on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :postal_code,   on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :station_type,  on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :street_name,   on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :street_number, on: [:read, :create, :update], omit_if_blank_on: [:create, :update], type: :string
-        attribute :active, on: :read, type: :boolean
-        attribute :deactivations, on: :read, type: :array, class_name: 'Deactivation'
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :active,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :boarding_time,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :integer
+
+        attribute :city,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :country,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :county, 
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :deactivations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Deactivation'
+
+        attribute :description,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :dhid,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :fixed,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :lat,
+                  on:   [:read, :create, :update],
+                  type: :float
+
+        attribute :lng,
+                  on:   [:read, :create, :update],
+                  type: :float
+
+        attribute :location_name,
+                  on:   [:read, :create, :update],
+                  type: :string
+
+        attribute :parking_time,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :integer
+
+        attribute :postal_code,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :station_type,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+        
+        attribute :street_name,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+
+        attribute :street_number,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
+        
+        attribute :tariff_codes,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :array
+
+        attribute :walker_boarding_time,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :integer
+
+        attribute :wheelchair_boarding_time,
+                  on:               [:read, :create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :integer
       end
     end
   end

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -39,7 +39,7 @@ module Ioki
                   omit_if_blank_on: [:create, :update],
                   type:             :string
 
-        attribute :county, 
+        attribute :county,
                   on:               [:read, :create, :update],
                   omit_if_blank_on: [:create, :update],
                   type:             :string
@@ -89,7 +89,7 @@ module Ioki
                   on:               [:read, :create, :update],
                   omit_if_blank_on: [:create, :update],
                   type:             :string
-        
+
         attribute :street_name,
                   on:               [:read, :create, :update],
                   omit_if_blank_on: [:create, :update],
@@ -99,7 +99,7 @@ module Ioki
                   on:               [:read, :create, :update],
                   omit_if_blank_on: [:create, :update],
                   type:             :string
-        
+
         attribute :tariff_codes,
                   on:               [:read, :create, :update],
                   omit_if_blank_on: [:create, :update],

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -296,4 +296,95 @@ RSpec.describe Ioki::OperatorApi do
         to eq(Ioki::Model::Operator::Place.new)
     end
   end
+
+  describe '#stations(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations')
+        result_with_index_data
+      end
+
+      expect(operator_client.stations('0815', options)).
+        to eq([Ioki::Model::Operator::Station.new])
+    end
+  end
+
+  describe '#station(product_id, station_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.station('0815', '4711', options)).
+        to eq(Ioki::Model::Operator::Station.new)
+    end
+  end
+
+  describe '#create_station(product_id, station)' do
+    let(:station) { Ioki::Model::Operator::Station.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_station('0815', station, options)).
+        to eq(Ioki::Model::Operator::Station.new)
+    end
+  end
+
+  describe '#update_station(product_id, station)' do
+    let(:station) { Ioki::Model::Operator::Station.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/4711')
+        expect(params[:method]).to eq(:patch)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_station('0815', station, options)).
+        to eq(Ioki::Model::Operator::Station.new)
+    end
+  end
+
+  describe '#delete_station(product_id, station_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/4711')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_station('0815', '4711', options)).
+        to eq(Ioki::Model::Operator::Station.new)
+    end
+  end
+
+  describe '#stations_fix(product_id, station_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/4711/fix')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.stations_fix('0815', '4711')).to be_a(Ioki::Model::Operator::Station)
+    end
+  end
+
+  describe '#stations_unfix(product_id, station_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/4711/unfix')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.stations_unfix('0815', '4711')).to be_a(Ioki::Model::Operator::Station)
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces station endpoints and the station model for the operator API.