### PR TITLE
Platform API | Add reassign task list endpoint

### DIFF
--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -123,6 +123,12 @@ module Ioki
         except:      [:create, :update, :delete],
         model_class: Ioki::Model::Platform::TaskList
       ),
+      Endpoints.custom_endpoints(
+        'task_list',
+        actions:     { 'reassign' => :patch },
+        path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
+        model_class: Ioki::Model::Platform::TaskList
+      ),
       Endpoints.crud_endpoints(
         :task,
         base_path:   [API_BASE_PATH, 'products', :id, 'task_lists', :id],

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -639,4 +639,17 @@ RSpec.describe Ioki::PlatformApi do
         to eq(Ioki::Model::Platform::LineStop.new)
     end
   end
+
+  describe '#task_list_reassign(product_id, id)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/products/0815/task_lists/1337/reassign')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(platform_client.task_list_reassign('0815', '1337', options)).
+        to eq(Ioki::Model::Platform::TaskList.new)
+    end
+  end
 end


### PR DESCRIPTION
Add a new custom endpoint to reassign a new vehicle to an existing task list.