### PR TITLE
Omit payment method on booking if it's nil

### DIFF
--- a/lib/ioki/model/passenger/booking.rb
+++ b/lib/ioki/model/passenger/booking.rb
@@ -12,7 +12,7 @@ module Ioki
         # The model does not return it but it's used when sending data to the server.
         attribute :ride_version, type: :integer, on: :create, unvalidated: true
         # The model does not return it but it's used when sending data to the server.
-        attribute :payment_method, type: :object, on: :create, class_name: 'PaymentMethod', unvalidated: true
+        attribute :payment_method, type: :object, on: :create, class_name: 'PaymentMethod', unvalidated: true, omit_if_nil_on: :create
       end
     end
   end

--- a/lib/ioki/model/passenger/booking.rb
+++ b/lib/ioki/model/passenger/booking.rb
@@ -4,15 +4,39 @@ module Ioki
   module Model
     module Passenger
       class Booking < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :verification_code, type: :string, on: [:read, :update]
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :verification_code,
+                  type: :string,
+                  on:   [:read, :update]
+
         # The model does not return it but it's used when sending data to the server.
-        attribute :ride_version, type: :integer, on: :create, unvalidated: true
+        attribute :ride_version,
+                  type:        :integer,
+                  on:          :create,
+                  unvalidated: true
+
         # The model does not return it but it's used when sending data to the server.
-        attribute :payment_method, type: :object, on: :create, class_name: 'PaymentMethod', unvalidated: true, omit_if_nil_on: :create
+        attribute :payment_method,
+                  type:           :object,
+                  on:             :create,
+                  class_name:     'PaymentMethod',
+                  unvalidated:    true,
+                  omit_if_nil_on: :create
       end
     end
   end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Ioki::PassengerApi do
     it 'calls request on the client with expected params' do
       expect(passenger_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('passenger/rides/RIDE_ID/booking')
-        expect(params[:body]).to eq({ data: { ride_version: 2, payment_method: nil } })
+        expect(params[:body]).to eq({ data: { ride_version: 2 } })
         [result_with_data, full_response]
       end
 


### PR DESCRIPTION
Turns out the API doesn't want to see the key at all and will throw a
422 if we send it as nil.