### PR TITLE
Operator API | Add fuel_type_options to Model::Operator::Vehicle

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -44,6 +44,10 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :string
 
+        attribute :fuel_type_options,
+                  on:   :read,
+                  type: :array
+
         attribute :last_known_position,
                   on:         :read,
                   type:       :object,

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -40,9 +40,8 @@ module Ioki
                   type:           :string
 
         attribute :fuel_type,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
-                  type:           :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :fuel_type_options,
                   on:   :read,


### PR DESCRIPTION
This adds the fuel_type_options attribute to the vehicle model of the operator api.