### PR TITLE
Operator API | Remove `fuel_type_options`

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -43,10 +43,6 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :string
 
-        attribute :fuel_type_options,
-                  on:   :read,
-                  type: :array
-
         attribute :last_known_position,
                   on:         :read,
                   type:       :object,


### PR DESCRIPTION
We decided to not expose the `fuel_type_options` as an array of strings. Instead we will hard code these options in the operator tool.