### PR TITLE
Passenger/Platform API | Add support for MBS

### DIFF
--- a/lib/ioki/model/passenger/booking.rb
+++ b/lib/ioki/model/passenger/booking.rb
@@ -30,6 +30,8 @@ module Ioki
                   on:          :create,
                   unvalidated: true
 
+        attribute :solution_id, type: :string, on: :create, omit_if_nil_on: :create
+
         # The model does not return it but it's used when sending data to the server.
         attribute :payment_method,
                   type:           :object,

--- a/lib/ioki/model/passenger/hop.rb
+++ b/lib/ioki/model/passenger/hop.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class Hop < Base
+        attribute :type, on: :read, type: :string
+        attribute :duration, on: :read, type: :integer
+        attribute :track, on: :read, type: :string
+        attribute :transport_mode, on: :read, type: :string
+        attribute :from, on: :read, type: :object, class_name: 'CalculatedPoint'
+        attribute :to, on: :read, type: :object, class_name: 'CalculatedPoint'
+        attribute :vehicle, on: :read, type: :object, class_name: 'Vehicle'
+        attribute :details, on: :read, type: :object, class_name: 'HopDetails'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/hop.rb
+++ b/lib/ioki/model/passenger/hop.rb
@@ -8,8 +8,10 @@ module Ioki
         attribute :duration, on: :read, type: :integer
         attribute :track, on: :read, type: :string
         attribute :transport_mode, on: :read, type: :string
-        attribute :from, on: :read, type: :object, class_name: 'CalculatedPoint'
-        attribute :to, on: :read, type: :object, class_name: 'CalculatedPoint'
+        attribute :from, on: :read, type: :object,
+          class_name: ['CalculatedPoint', 'RequestedPoint', 'PublicTransportStop']
+        attribute :to, on: :read, type: :object,
+          class_name: ['CalculatedPoint', 'RequestedPoint', 'PublicTransportStop']
         attribute :vehicle, on: :read, type: :object, class_name: 'Vehicle'
         attribute :details, on: :read, type: :object, class_name: 'HopDetails'
       end

--- a/lib/ioki/model/passenger/hop_details.rb
+++ b/lib/ioki/model/passenger/hop_details.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class HopDetails < Base
+        attribute :direction, on: :read, type: :string
+        attribute :name, on: :read, type: :string
+        attribute :transport_type, on: :read, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/offered_solution.rb
+++ b/lib/ioki/model/passenger/offered_solution.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class OfferedSolution < Base
+        attribute :type, on: :read, type: :string
+        attribute :id, on: :read, type: :string
+        attribute :created_at, on: :read, type: :date_time
+        attribute :updated_at, on: :read, type: :date_time
+        attribute :bookable, on: :read, type: :boolean
+        attribute :solution_type, on: :read, type: :string
+        attribute :fare, on: :read, type: :object, class_name: 'Fare'
+        attribute :hops, on: :read, type: :array, class_name: 'Hop'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/public_transport_stop.rb
+++ b/lib/ioki/model/passenger/public_transport_stop.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class PublicTransportStop < Base
+        attribute :type, on: :read, type: :string
+        attribute :city, type: :string, on: :read
+        attribute :country, type: :string, on: :read
+        attribute :county, type: :string, on: :read
+        attribute :current_arrival, type: :string, on: :read
+        attribute :current_departure, type: :string, on: :read
+        attribute :current_platform, type: :string, on: :read
+        attribute :dhid, type: :string, on: :read
+        attribute :display_times, type: :array, on: :read
+        attribute :hafas_ext_id, type: :array, on: :read
+        attribute :lat, type: :float, on: :read
+        attribute :lng, type: :float, on: :read
+        attribute :location_name, type: :array, on: :read
+        attribute :postal_code, type: :array, on: :read
+        attribute :scheduled_arrival, type: :string, on: :read
+        attribute :scheduled_departure, type: :string, on: :read
+        attribute :scheduled_platform, type: :string, on: :read
+        attribute :street_name, type: :string, on: :read
+        attribute :street_number, type: :string, on: :read
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -46,6 +46,7 @@ module Ioki
         attribute :version, type: :integer, on: [:read, :update]
         attribute :fare, on: :read, type: :object, class_name: 'Fare'
         attribute :ticket, on: :read, type: :object, class_name: 'Ticket'
+        attribute :offered_solutions, on: :read, type: :array, class_name: 'OfferedSolution'
       end
     end
   end

--- a/lib/ioki/model/platform/features.rb
+++ b/lib/ioki/model/platform/features.rb
@@ -8,6 +8,7 @@ module Ioki
 
         attribute :failed_payment_handling, type: :boolean, on: :read
         attribute :payment, type: :boolean, on: :read
+        attribute :supports_multiple_booking_solutions, type: :boolean, on: :read
       end
     end
   end

--- a/lib/ioki/model/platform/product.rb
+++ b/lib/ioki/model/platform/product.rb
@@ -23,6 +23,7 @@ module Ioki
         attribute :service_time_info, on: :read, type: :string
         attribute :timezone, on: :read, type: :object, class_name: 'Timezone'
         attribute :tipping, on: :read, type: :object, class_name: 'Tipping'
+        attribute :features, on: :read, type: :object, class_name: 'Features'
         attribute :version, on: :read, type: :integer
       end
     end


### PR DESCRIPTION
## Changes

* Allow a ride to be booked with a specific offered solution by adding `Passenger::Booking#solution_id`
* Add `Passenger::OfferedSolution`, `Passenger::Hop` and `Passenger::HopDetails` to read `Ride#offered_solutions`
* Add `Platform::Features#supports_multiple_booking_solutions`
* Add `Product#features` when reading a product from the platform API