### PR TITLE
Operator Api | Refine operator models

### DIFF
--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -39,8 +39,10 @@ module Ioki
                   type:           :string
 
         attribute :locale,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:               [:create, :read, :update],
+                  omit_if_nil_on:   [:create, :update],
+                  omit_if_blank_on: [:create, :update],
+                  type:             :string
 
         attribute :locked_at,
                   on:   :read,

--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -29,37 +29,35 @@ module Ioki
                   type: :string
 
         attribute :first_name,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :last_name,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :locale,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: [:create, :read],
-                  type:             :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :locked_at,
                   on:   :read,
                   type: :date_time
 
         attribute :phone_number,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: [:create, :read],
-                  type:             :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :pin,
                   on:   :read,
                   type: :string
 
         attribute :username,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :version,
                   on:   :read,

--- a/lib/ioki/model/operator/place.rb
+++ b/lib/ioki/model/operator/place.rb
@@ -25,28 +25,33 @@ module Ioki
                   type: :string
 
         attribute :description,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :lat,
-                  on:   [:create, :read, :update],
-                  type: :float
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :float
 
         attribute :lng,
-                  on:   [:create, :read, :update],
-                  type: :float
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :float
 
         attribute :location_name,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :postal_code,
                   on:   [:create, :read, :update],
                   type: :string
 
         attribute :slug,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :street_name,
                   on:   [:create, :read, :update],

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -25,24 +25,20 @@ module Ioki
                   type: :boolean
 
         attribute :boarding_time,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :integer
+                  on:   [:read, :create, :update],
+                  type: :integer
 
         attribute :city,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :country,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :county,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :deactivations,
                   on:         :read,
@@ -50,70 +46,66 @@ module Ioki
                   class_name: 'Deactivation'
 
         attribute :description,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :dhid,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :fixed,
                   on:   :read,
                   type: :boolean
 
         attribute :lat,
-                  on:   [:read, :create, :update],
-                  type: :float
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :float
 
         attribute :lng,
-                  on:   [:read, :create, :update],
-                  type: :float
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :float
 
         attribute :location_name,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :parking_time,
+                  on:   [:read, :create, :update],
+                  type: :integer
+
+        attribute :postal_code,
                   on:   [:read, :create, :update],
                   type: :string
 
-        attribute :parking_time,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :integer
-
-        attribute :postal_code,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
-
         attribute :station_type,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :street_name,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :street_number,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :tariff_codes,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :array
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :array
 
         attribute :walker_boarding_time,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :integer
+                  on:   [:read, :create, :update],
+                  type: :integer
 
         attribute :wheelchair_boarding_time,
-                  on:               [:read, :create, :update],
-                  omit_if_blank_on: [:create, :update],
-                  type:             :integer
+                  on:   [:read, :create, :update],
+                  type: :integer
       end
     end
   end

--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -29,8 +29,9 @@ module Ioki
                   type: :date_time
 
         attribute :ad_hoc_bookable,
-                  on:   [:create, :read, :update],
-                  type: :boolean
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
 
         attribute :deactivated,
                   on:   :read,
@@ -42,33 +43,32 @@ module Ioki
                   class_name: %w[Place Station]
 
         attribute :end_location_id,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: :read,
-                  type:           :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :end_location_type,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: :read,
-                  type:           :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :ends_at,
                   on:             [:create, :read, :update],
-                  omit_if_nil_on: :read,
+                  omit_if_nil_on: [:create, :update],
                   type:           :date_time
 
         attribute :matching_configuration_id,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :paused,
                   on:   :read,
                   type: :boolean
 
         attribute :pauses,
-                  on:               [:read, :create],
-                  omit_if_blank_on: [:create],
-                  type:             :array,
-                  class_name:       'Pause'
+                  on:             [:read, :create],
+                  omit_if_nil_on: [:create],
+                  type:           :array,
+                  class_name:     'Pause'
 
         attribute :planned_ends_at,
                   on:   :read,
@@ -79,8 +79,9 @@ module Ioki
                   type: :date_time
 
         attribute :prebookable,
-                  on:   [:create, :read, :update],
-                  type: :boolean
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
 
         attribute :start_location,
                   on:         :read,
@@ -89,30 +90,28 @@ module Ioki
 
         attribute :start_location_id,
                   on:             [:create, :read, :update],
-                  omit_if_nil_on: :read,
+                  omit_if_nil_on: [:create, :update],
                   type:           :string
 
         attribute :start_location_type,
-                  on:               [:create, :read, :update],
-                  omit_if_blank_on: :read,
-                  type:             :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :starts_at,
                   on:             [:create, :read, :update],
-                  omit_if_nil_on: :read,
+                  omit_if_nil_on: [:create, :update],
                   type:           :date_time
 
         attribute :state,
-                  on:   [:create, :read, :update],
-                  type: :string
-
-        attribute :state_options,
-                  on:   :read,
-                  type: :array
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :vehicle_id,
-                  on:   [:create, :read, :reassign],
-                  type: :string
+                  on:             [:create, :read, :reassign],
+                  omit_if_nil_on: [:create, :reassign],
+                  type:           :string
       end
     end
   end

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -40,8 +40,9 @@ module Ioki
                   type:           :string
 
         attribute :fuel_type,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :last_known_position,
                   on:         :read,
@@ -49,8 +50,9 @@ module Ioki
                   class_name: 'VehiclePosition'
 
         attribute :license_plate,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :manufacturer,
                   on:             [:create, :read, :update],
@@ -63,8 +65,9 @@ module Ioki
                   type:           :string
 
         attribute :nickname,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
 
         attribute :phone_number,
                   on:   [:create, :read, :update],

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -77,7 +77,6 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:start_location_type).as(:string) }
     it { is_expected.to define_attribute(:starts_at).as(:date_time) }
     it { is_expected.to define_attribute(:state).as(:string) }
-    it { is_expected.to define_attribute(:state_options).as(:array) }
     it { is_expected.to define_attribute(:vehicle_id).as(:string) }
   end
 


### PR DESCRIPTION
As I was working with the new LeightweightSchema I found some inconsistencies between the ioki-ruby operator models and the schemas in triebwerk. This PR will clear these inconsistencies.