### PR TITLE
`Endpoints::Create` | Allow an array as path argument

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -23,7 +23,7 @@ module Ioki
       end
 
       def full_path
-        base_path + [resource_path_name]
+        (base_path + [resource_path_name]).flatten
       end
 
       def call(client, model, args = [], options = {})

--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -122,14 +122,14 @@ module Ioki
       Endpoints::Create.new(
         :logpay_customer,
         base_path:            [API_BASE_PATH],
-        path:                 'logpay/customer',
+        path:                 ['logpay', 'customer'],
         model_class:          Ioki::Model::Passenger::LogpayUrl,
         outgoing_model_class: Ioki::Model::Passenger::LogpayCustomer
       ),
       Endpoints::Create.new(
         :logpay_payment_method,
         base_path:            [API_BASE_PATH],
-        path:                 'logpay/payment_method',
+        path:                 ['logpay', 'payment_method'],
         model_class:          Ioki::Model::Passenger::LogpayUrl,
         outgoing_model_class: Ioki::Model::Passenger::LogpayPaymentMethod
       ),

--- a/spec/ioki/endpoints/create_spec.rb
+++ b/spec/ioki/endpoints/create_spec.rb
@@ -45,4 +45,15 @@ RSpec.describe Ioki::Endpoints::Create do
       end
     end
   end
+
+  it 'supports an array as a path' do
+    endpoint = described_class.new(
+      'ride',
+      base_path:   ['passenger'],
+      path:        ['rides', 'current'],
+      model_class: model_class
+    )
+
+    expect(endpoint.full_path).to eq(['passenger', 'rides', 'current'])
+  end
 end


### PR DESCRIPTION
This allows an `Endpoints::Create` to have an array as a `path` arguments.

Until now we had to do the following:

```ruby
      Endpoints::Create.new(
        :logpay_customer,
        base_path:            [API_BASE_PATH],
        path:                 'logpay/customer'
      ),
```

With this PR, we can do the following:

```ruby
      Endpoints::Create.new(
        :logpay_customer,
        base_path:            [API_BASE_PATH],
        path:                 ['logpay', 'customer']
      ),
```

Without this PR, this would fail with the following error:

```
ArgumentError:
       path: must consist of Strings and Symbols only
     # ./lib/ioki/apis/endpoints/endpoints.rb:47:in `url_elements'
     # ./lib/ioki/apis/endpoints/create.rb:37:in `call'
```

This behavior is already present for `Endpoints::ShowSingular`. This PR applies the same behavior to `Endpoints::Create`.