### PR TITLE
Operator API | Providers

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -8,6 +8,12 @@ module Ioki
     API_BASE_PATH = 'operator'
     ENDPOINTS = [
       Endpoints.crud_endpoints(
+        :provider,
+        base_path:   [API_BASE_PATH],
+        model_class: Ioki::Model::Operator::Provider,
+        except:      [:create, :update, :delete]
+      ),
+      Endpoints.crud_endpoints(
         :product,
         base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Operator::Product,

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -24,6 +24,30 @@ RSpec.describe Ioki::OperatorApi do
   let(:full_response) { instance_double(Faraday::Response, 'full_response', headers: {}) }
   let(:options) { { options: :example } }
 
+  describe '#providers' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers')
+        result_with_index_data
+      end
+
+      expect(operator_client.providers(options))
+        .to eq([Ioki::Model::Operator::Provider.new])
+    end
+  end
+
+  describe '#provider(id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.provider('0815', options))
+        .to eq(Ioki::Model::Operator::Provider.new)
+    end
+  end
+
   describe '#products' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
Allows to `%i[index show]` providers from the operator API.