### PR TITLE
Operator Api | Add endpoints for DriverVehicleConnection

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -124,6 +124,12 @@ module Ioki
         :station_categories,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::StationCategory
+      ),
+      Endpoints.crud_endpoints(
+        :driver_vehicle_connection,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::DriverVehicleConnection,
+        except:      [:update]
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/driver_vehicle_connection.rb
+++ b/lib/ioki/model/operator/driver_vehicle_connection.rb
@@ -4,12 +4,39 @@ module Ioki
   module Model
     module Operator
       class DriverVehicleConnection < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: [:update, :read], type: :string
-        attribute :vehicle, on: :read, type: :object, class_name: 'Vehicle'
-        attribute :driver, on: :read, type: :object, class_name: 'Driver'
-        attribute :activated_at, on: :read, type: :date_time
-        attribute :deactivated_at, on: [:create, :read], type: :date_time, omit_if_blank_on: :create
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :activated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :deactivated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :driver,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Driver'
+
+        attribute :driver_id,
+                  on:   [:create, :read],
+                  type: :string
+
+        attribute :vehicle,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Vehicle'
+
+        attribute :vehicle_id,
+                  on:   [:create, :read],
+                  type: :string
       end
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -824,7 +824,7 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-    describe '#driver_vehicle_connections(product_id, driver_vehicle_connection_id)' do
+  describe '#driver_vehicle_connections(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('operator/products/0815/driver_vehicle_connections')
@@ -848,7 +848,7 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#create_driver_vehicle_connection(product_id, driver_vehicle_connection_id)' do
+  describe '#create_driver_vehicle_connection(product_id, driver_id, vehicle_id)' do
     let(:driver_vehicle_connection) { Ioki::Model::Operator::DriverVehicleConnection.new({ id: '5105' }) }
 
     it 'calls request on the client with expected params' do

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -823,4 +823,56 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::StationCategory)
     end
   end
+
+    describe '#driver_vehicle_connections(product_id, driver_vehicle_connection_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_vehicle_connections')
+        result_with_index_data
+      end
+
+      expect(operator_client.driver_vehicle_connections('0815', options))
+        .to all(be_a(Ioki::Model::Operator::DriverVehicleConnection))
+    end
+  end
+
+  describe '#driver_vehicle_connection(product_id, driver_vehicle_connection_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_vehicle_connections/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.driver_vehicle_connection('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::DriverVehicleConnection)
+    end
+  end
+
+  describe '#create_driver_vehicle_connection(product_id, driver_vehicle_connection_id)' do
+    let(:driver_vehicle_connection) { Ioki::Model::Operator::DriverVehicleConnection.new({ id: '5105' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_vehicle_connections')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_driver_vehicle_connection('0815', driver_vehicle_connection, options))
+        .to be_a(Ioki::Model::Operator::DriverVehicleConnection)
+    end
+  end
+
+  describe '#delete_driver_vehicle_connection(product_id, driver_vehicle_connection_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_vehicle_connections/4711')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_driver_vehicle_connection('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::DriverVehicleConnection)
+    end
+  end
 end


### PR DESCRIPTION
This PR will introduce the endpoints and model for `DriverVehicleConnection` for the operator api.