### PR TITLE
Ignore unrecognized rubocop cops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: |
-          bundle exec rubocop
+          bundle exec rubocop --ignore-unrecognized-cops
 
   backend-services:
     runs-on: ubuntu-20.04

--- a/.rubocop
+++ b/.rubocop
@@ -1,0 +1,1 @@
+--ignore-unrecognized-cops


### PR DESCRIPTION
When Triebwerk updates its rubocop versions, it sometimes adds cops to the config files that older versions don't know about. [Rubocop recently added](https://github.com/rubocop/rubocop/pull/10630) the `--ignore-unrecognized-cops` flag for exactly this usecase.

I'm sorry for not figuring this out earlier.