### PR TITLE
Operator Api | Add vehicle position endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -160,7 +160,7 @@ module Ioki
         except:      [:index, :show]
       ),
       Endpoints.crud_endpoints(
-        :vehicle_position,
+        :position,
         base_path:   [API_BASE_PATH, 'products', :id, 'vehicles', :id],
         model_class: Ioki::Model::Operator::VehiclePosition,
         except:      [:show, :index, :update, :delete]

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -158,6 +158,12 @@ module Ioki
         },
         model_class: Ioki::Model::Operator::Rating,
         except:      [:index, :show]
+      ),
+      Endpoints.crud_endpoints(
+        :vehicle_position,
+        base_path:   [API_BASE_PATH, 'products', :id, 'vehicles', :id],
+        model_class: Ioki::Model::Operator::VehiclePosition,
+        except:      [:show, :index, :update, :delete]
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/vehicle_position.rb
+++ b/lib/ioki/model/operator/vehicle_position.rb
@@ -45,8 +45,9 @@ module Ioki
                   type: :float
 
         attribute :on_route,
-                  on:   [:create, :read],
-                  type: :boolean
+                  on:             [:create, :read],
+                  omit_if_nil_on: :create,
+                  type:           :boolean
 
         attribute :recorded_at,
                   on:   [:create, :read],

--- a/lib/ioki/model/operator/vehicle_position.rb
+++ b/lib/ioki/model/operator/vehicle_position.rb
@@ -44,9 +44,17 @@ module Ioki
                   on:   [:create, :read],
                   type: :float
 
+        attribute :on_route,
+                  on:   [:create, :read],
+                  type: :boolean
+
         attribute :recorded_at,
                   on:   [:create, :read],
                   type: :date_time
+
+        attribute :source,
+                  on:   [:create, :read],
+                  type: :string
 
         attribute :speed,
                   on:   [:create, :read],

--- a/lib/ioki/model/operator/vehicle_position.rb
+++ b/lib/ioki/model/operator/vehicle_position.rb
@@ -8,18 +8,49 @@ module Ioki
           'operator_api--v20210101--vehicle_position_without_vehicle'
         end
 
-        attribute :accuracy, on: :read, type: :float
-        attribute :altitude, on: :read, type: :float
-        attribute :altitude_accuracy, on: :read, type: :float
-        attribute :created_at, on: :read, type: :date_time
-        attribute :heading, on: :read, type: :float
-        attribute :id, on: :read, type: :string
-        attribute :lat, on: :read, type: :float
-        attribute :lng, on: :read, type: :float
-        attribute :product_id, on: :read, type: :string
-        attribute :recorded_at, on: :read, type: :date_time
-        attribute :speed, on: :read, type: :float
-        attribute :type, on: :read, type: :string
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :accuracy,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :altitude,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :altitude_accuracy,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :heading,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :lat,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :lng,
+                  on:   [:create, :read],
+                  type: :float
+
+        attribute :recorded_at,
+                  on:   [:create, :read],
+                  type: :date_time
+
+        attribute :speed,
+                  on:   [:create, :read],
+                  type: :float
       end
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -992,17 +992,17 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#create_vehicle_position(product_id, vehicle_id, vehicle_position)' do
+  describe '#create_position(product_id, vehicle_id, vehicle_position)' do
     let(:vehicle_position) { Ioki::Model::Operator::VehiclePosition.new({ id: '5105' }) }
 
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/vehicles/4711/vehicle_positions')
+        expect(params[:url].to_s).to eq('operator/products/0815/vehicles/4711/positions')
         expect(params[:method]).to eq(:post)
         [result_with_data, full_response]
       end
 
-      expect(operator_client.create_vehicle_position('0815', '4711', vehicle_position, options))
+      expect(operator_client.create_position('0815', '4711', vehicle_position, options))
         .to be_a(Ioki::Model::Operator::VehiclePosition)
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -991,4 +991,19 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Rating)
     end
   end
+
+  describe '#create_vehicle_position(product_id, vehicle_id, vehicle_position)' do
+    let(:vehicle_position) { Ioki::Model::Operator::VehiclePosition.new({ id: '5105' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/vehicles/4711/vehicle_positions')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_vehicle_position('0815', '4711', vehicle_position, options))
+        .to be_a(Ioki::Model::Operator::VehiclePosition)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the `create` endpoint for vehicle positions for the operator api.