### PR TITLE
Operator Api | Add MatchingConfiguration CRUD endpoints

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -59,8 +59,7 @@ module Ioki
       Endpoints.crud_endpoints(
         :matching_configuration,
         base_path:   [API_BASE_PATH, 'products', :id],
-        model_class: Ioki::Model::Operator::MatchingConfiguration,
-        except:      [:create, :update, :delete]
+        model_class: Ioki::Model::Operator::MatchingConfiguration
       ),
       Endpoints.crud_endpoints(
         :task_list,

--- a/lib/ioki/model/operator/matching_configuration.rb
+++ b/lib/ioki/model/operator/matching_configuration.rb
@@ -26,8 +26,8 @@ module Ioki
                   class_name: 'Area'
 
         attribute :area_geojson,
-                  on:         [:create, :update],
-                  type:       :string
+                  on:   [:create, :update],
+                  type: :string
 
         attribute :description,
                   on:   [:create, :read, :update],

--- a/lib/ioki/model/operator/matching_configuration.rb
+++ b/lib/ioki/model/operator/matching_configuration.rb
@@ -25,13 +25,150 @@ module Ioki
                   type:       :object,
                   class_name: 'Area'
 
-        attribute :name,
-                  on:   :read,
+        attribute :area_geojson,
+                  on:         [:create, :update],
+                  type:       :object,
+                  class_name: 'Area'
+
+        attribute :description,
+                  on:   [:create, :read, :update],
                   type: :string
 
-        attribute :slug,
-                  on:   :read,
+        attribute :detour_duration_factor,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_additional_loaded_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_additional_passenger_direct_routing_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_additional_passenger_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_additional_ride_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_loaded_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_passenger_direct_routing_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_passenger_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_passenger_second,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :gain_per_ride_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :matching_considered_stations,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :matching_max_enclosed_tasks,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :matching_mode_dropoff,
+                  on:   [:create, :read, :update],
                   type: :string
+
+        attribute :matching_mode_pickup,
+                  on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :max_request_time_deviation,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :max_walking_duration,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :maximum_detour_duration,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :minimum_detour_duration,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :name,
+                  on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :penalty_per_additional_driving_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_additional_empty_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_cost_benefit_ratio,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_delay_second,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_driving_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_driving_second,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_empty_duration,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_passenger_waiting_second,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :penalty_per_passenger_walking_second,
+                  on:   [:create, :read, :update],
+                  type: :float
+
+        attribute :prevent_address_to_address_matching,
+                  on:   [:create, :read, :update],
+                  type: :boolean
+
+        attribute :prevent_station_to_station_matching,
+                  on:   [:create, :read, :update],
+                  type: :boolean
+
+        attribute :ride_distance_min,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :slug,
+                  on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :streak_split_buffer_threshold,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :time_window_collapse_threshold,
+                  on:   [:create, :read, :update],
+                  type: :integer
       end
     end
   end

--- a/lib/ioki/model/operator/matching_configuration.rb
+++ b/lib/ioki/model/operator/matching_configuration.rb
@@ -27,8 +27,7 @@ module Ioki
 
         attribute :area_geojson,
                   on:         [:create, :update],
-                  type:       :object,
-                  class_name: 'Area'
+                  type:       :string
 
         attribute :description,
                   on:   [:create, :read, :update],

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -442,6 +442,49 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#create_matching_configuration(product_id, matching_configuration)' do
+    let(:matching_configuration) { Ioki::Model::Operator::MatchingConfiguration.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/matching_configurations')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_matching_configuration('0815', matching_configuration, options))
+        .to be_a(Ioki::Model::Operator::MatchingConfiguration)
+    end
+  end
+
+  describe '#update_matching_configuration(product_id, matching_configuration)' do
+    let(:matching_configuration) { Ioki::Model::Operator::MatchingConfiguration.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/matching_configurations/4711')
+        expect(params[:method]).to eq(:patch)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_matching_configuration('0815', matching_configuration, options))
+        .to be_a(Ioki::Model::Operator::MatchingConfiguration)
+    end
+  end
+
+  describe '#delete_matching_configuration(product_id, matching_configuration_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/matching_configurations/4711')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_matching_configuration('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::MatchingConfiguration)
+    end
+  end
+
   describe '#task_lists(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
This PR will add CRUD endpoints for the MatchingConfiguration resource. For now, these endpoints will stay operator-api-only endpoints! 