### PR TITLE
Operator Api | Add current_journey endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -73,6 +73,12 @@ module Ioki
         path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
         model_class: Ioki::Model::Operator::TaskList
       ),
+      Endpoints.custom_endpoints(
+        'task_lists',
+        actions:     { 'current_journey' => :get },
+        path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
+        model_class: Ioki::Model::Operator::Journey
+      ),
       Endpoints.crud_endpoints(
         :pause,
         base_path:   [API_BASE_PATH, 'products', :id, 'task_lists', :id],

--- a/lib/ioki/model/operator/journey.rb
+++ b/lib/ioki/model/operator/journey.rb
@@ -4,12 +4,30 @@ module Ioki
   module Model
     module Operator
       class Journey < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :legs, type: :array, on: :read, class_name: 'Leg'
-        attribute :version, type: :integer, on: :read
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :legs,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Leg'
+
+        attribute :version,
+                  on:   :read,
+                  type: :integer
       end
     end
   end

--- a/lib/ioki/model/operator/leg.rb
+++ b/lib/ioki/model/operator/leg.rb
@@ -4,20 +4,62 @@ module Ioki
   module Model
     module Operator
       class Leg < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :destination_task_calculated_time, type: :string, on: :read
-        attribute :destination_task_waypoint_type, type: :string, on: :read
-        attribute :distance, type: :integer, on: :read
-        attribute :duration, type: :integer, on: :read
-        attribute :geo_track, type: :string, on: :read
-        attribute :geo_track_durations, type: :array, on: :read
-        attribute :leg_order, type: :integer, on: :read
-        attribute :maneuvers, type: :array, on: :read
-        attribute :maneuvers_calculated_at, type: :date_time, on: :read
-        attribute :destination_task, type: :object, on: :read, class_name: 'Task'
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :destination_task_calculated_time,
+                  on:   :read,
+                  type: :string
+
+        attribute :destination_task_waypoint_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :distance,
+                  on:   :read,
+                  type: :integer
+
+        attribute :duration,
+                  on:   :read,
+                  type: :integer
+
+        attribute :geo_track,
+                  on:   :read,
+                  type: :string
+
+        attribute :geo_track_durations,
+                  on:   :read,
+                  type: :array
+
+        attribute :leg_order,
+                  on:   :read,
+                  type: :integer
+
+        attribute :maneuvers,
+                  on:   :read,
+                  type: :array
+
+        attribute :maneuvers_calculated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :destination_task,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Task'
       end
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -532,6 +532,18 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#task_lists_current_journey(product_id, task_list_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/task_lists/4711/current_journey')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.task_lists_current_journey('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::Journey)
+    end
+  end
+
   describe '#pauses(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
This PR will add the current_journey endpoint for the operator api. This is a custom endpoint. This will be the path:
`/api/operator/products/:product_id/task_lists/:id/current_journey`.