### PR TITLE
General | Handle empty response body in endpoints

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -40,6 +40,8 @@ module Ioki
           params: options[:params]
         )
 
+        return if parsed_response.nil?
+
         model_class.new(parsed_response['data'], response.headers[:etag])
       end
     end

--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -31,6 +31,8 @@ module Ioki
           params: options[:params]
         )
 
+        return if parsed_response.nil?
+
         model_class.new(parsed_response['data'])
       end
     end

--- a/lib/ioki/apis/endpoints/update.rb
+++ b/lib/ioki/apis/endpoints/update.rb
@@ -39,6 +39,8 @@ module Ioki
           params: options[:params]
         )
 
+        return if parsed_response.nil?
+
         model_class.new(parsed_response['data'], response.headers[:etag])
       end
     end

--- a/spec/ioki/endpoints/delete_spec.rb
+++ b/spec/ioki/endpoints/delete_spec.rb
@@ -5,19 +5,34 @@ RSpec.describe Ioki::Endpoints::Delete do
   let(:client)      { instance_double(Ioki::Client, 'client', build_request_url: 'url') }
   let(:endpoint)    { described_class.new('product', base_path: ['base_path'], model_class: model_class) }
   let(:params)      { instance_double(Hash, 'params') }
+  let(:response)    { { 'data' => { 'id' => '0815' } } }
 
   it 'calls #request on the client instantiating a class from the result' do
     expect(client).to receive(:request).with(
       url:    'url',
       method: :delete,
       params: params
-    ).and_return(
-      { 'data' => { 'id' => '0815' } }
-    )
+    ).and_return(response)
 
     result = endpoint.call(client, ['0815'], params: params)
 
     expect(result).to be_a(Ioki::Model::Platform::Product)
     expect(result.id).to eq('0815')
+  end
+
+  context 'when the response body is empty' do
+    let(:response) { nil }
+
+    it 'returns nil' do
+      expect(client).to receive(:request).with(
+        url:    'url',
+        method: :delete,
+        params: params
+      ).and_return(response)
+
+      result = endpoint.call(client, ['0815'], params: params)
+
+      expect(result).to be_nil
+    end
   end
 end

--- a/spec/ioki/endpoints/update_spec.rb
+++ b/spec/ioki/endpoints/update_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Ioki::Endpoints::Update do
     let(:endpoint) { described_class.new('product', base_path: ['base'], model_class: model_class) }
     let(:client)   { instance_double(Ioki::Client, 'client', build_request_url: url) }
     let(:params)   { instance_double(Hash, 'params') }
+    let(:response) do
+      [
+        { 'data' => { 'id' => '0815', name: 'attributes altered by server' } },
+        instance_double(Faraday::Response, headers: { etag: 'ETAG' })
+      ]
+    end
 
     before { allow(model).to receive(:serialize).with(:update).and_return(serialized_model) }
 
@@ -19,12 +25,7 @@ RSpec.describe Ioki::Endpoints::Update do
         method: :patch,
         body:   { data: serialized_model },
         params: params
-      ).and_return(
-        [
-          { 'data' => { 'id' => '0815', name: 'attributes altered by server' } },
-          instance_double(Faraday::Response, headers: { etag: 'ETAG' })
-        ]
-      )
+      ).and_return(response)
 
       result = endpoint.call(client, model, ['0815'], model_class: model_class, params: params)
 
@@ -43,6 +44,23 @@ RSpec.describe Ioki::Endpoints::Update do
           ArgumentError,
           "#{model} is not an instance of #{Ioki::Model::Platform::Product}"
         )
+      end
+    end
+
+    context 'when the response body is empty' do
+      let(:response) { nil }
+
+      it 'returns nil' do
+        expect(client).to receive(:request).with(
+          url:    url,
+          method: :patch,
+          body:   { data: serialized_model },
+          params: params
+        ).and_return(response)
+
+        result = endpoint.call(client, model, ['0815'], model_class: model_class, params: params)
+
+        expect(result).to be_nil
       end
     end
   end


### PR DESCRIPTION
This PR will add a strategy for handling empty response bodies to `create`, `delete` and `update` endpoints.

Without this change, api requests that only return response headers will lead to the following error message:

```
lib/ioki/apis/endpoints/create.rb:43:in `call': undefined method `[]' for nil:NilClass (NoMethodError)
```

resolves #151 