### PR TITLE
General | Enhance Error Handling

### DIFF
--- a/lib/ioki/http_adapter.rb
+++ b/lib/ioki/http_adapter.rb
@@ -24,8 +24,10 @@ module Ioki
             logger.filter(/("token"=>")([^"]+)/, '\1[REMOVED]')
           end
         end
-        f.response :json # decode response bodies as JSON
-        f.request :json # encode request bodies as JSON
+        # decode response bodies with content_type 'json' as JSON
+        f.response :json, content_type: /\bjson$/
+        # encode request bodies as JSON
+        f.request :json
       end
     end
 


### PR DESCRIPTION
At the moment, ioki-ruby is not able to handle errors that have a non-json response body (e.g. some errors like `404` - `ActiveRecord::RecordNotFound` come with a 'text/html' response body). Reason being, the `JsonParse` middleware of Faraday tries to parse the response body to json no matter what. This however causes ioki-ruby to raise a `Faraday::ParsingError` when the response body is not a json.

This PR will add the `content_typ` setting to the JsonParse middleware of Faraday which ensures that only response bodies of type json will be parsed. Response bodies of any other type will not be parsed and thus will not raise the infamous `Faraday::ParsingError`.