### PR TITLE
Platform API | Add endpoints for captchas

### DIFF
--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -223,6 +223,18 @@ module Ioki
         actions:     { 'set_default' => :patch },
         path:        [API_BASE_PATH, 'providers', :id, 'operators', :id],
         model_class: Ioki::Model::Platform::Operator
+      ),
+      Endpoints.custom_endpoints(
+        :captcha,
+        actions:     { 'regenerate' => :patch },
+        path:        [API_BASE_PATH, 'captchas', :id],
+        model_class: Ioki::Model::Platform::Captcha
+      ),
+      Endpoints::Create.new(
+        :captcha_solution,
+        base_path:   [API_BASE_PATH, 'captchas', :id],
+        path:        'solution',
+        model_class: Ioki::Model::Platform::Captcha
       )
     ].freeze
   end

--- a/lib/ioki/model/platform/captcha.rb
+++ b/lib/ioki/model/platform/captcha.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class Captcha < Base
+        attribute :type, on: :read, type: :string
+        attribute :id, on: :read, type: :string
+        attribute :created_at, on: :read, type: :date_time
+        attribute :updated_at, on: :read, type: :date_time
+        attribute :captcha_type, on: :read, type: :string
+        attribute :question_prompt, on: :read, type: :string
+        attribute :image_url, on: :read, type: :string
+
+        attribute :solution, on: :create, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/phone_verification_request.rb
+++ b/lib/ioki/model/platform/phone_verification_request.rb
@@ -14,6 +14,7 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :phone_number, on: [:read, :create], type: :string
         attribute :locale, on: [:create], type: :string, unvalidated: true
+        attribute :captcha, type: :object, on: :read, class_name: 'Captcha'
       end
     end
   end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -732,4 +732,31 @@ RSpec.describe Ioki::PlatformApi do
         .to be_a(Ioki::Model::Platform::Operator)
     end
   end
+
+  describe '#create_captcha_solution(id, captcha)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/captchas/0815/solution')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      captcha = Ioki::Model::Platform::Captcha.new(solution: 'w3sd')
+      expect(platform_client.create_captcha_solution('0815', captcha, options))
+        .to eq(Ioki::Model::Platform::Captcha.new)
+    end
+  end
+
+  describe '#captcha_regenerate(id)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/captchas/0815/regenerate')
+        expect(params[:method]).to eq(:patch)
+        [result_with_data, full_response]
+      end
+
+      expect(platform_client.captcha_regenerate('0815', options))
+        .to eq(Ioki::Model::Platform::Captcha.new)
+    end
+  end
 end


### PR DESCRIPTION
This adds required endpoints to implement captchas on the platform API, namely:

* Post a captcha solution `/api/platform/captchas/{id}/solution`
* Regenerate the captchas task `/api/platform/captchas/{id}/regenerate`

It also adds the captcha model and adds it to the response of the endpoint "Create a new Phone Verification Request" `/api/platform/providers/{provider_id}/phone_verification_requests`