### PR TITLE
Operator Api | Remove rating endpoints

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -154,17 +154,6 @@ module Ioki
         model_class: Ioki::Model::Operator::Task
       ),
       Endpoints.crud_endpoints(
-        :rating,
-        base_path:   [API_BASE_PATH, 'products', :id, 'rides', :id],
-        paths:       {
-          create: 'rating',
-          update: 'rating',
-          delete: 'rating'
-        },
-        model_class: Ioki::Model::Operator::Rating,
-        except:      [:index, :show]
-      ),
-      Endpoints.crud_endpoints(
         :position,
         base_path:   [API_BASE_PATH, 'products', :id, 'vehicles', :id],
         model_class: Ioki::Model::Operator::VehiclePosition,

--- a/lib/ioki/model/operator/rating.rb
+++ b/lib/ioki/model/operator/rating.rb
@@ -21,11 +21,11 @@ module Ioki
                   type: :date_time
 
         attribute :comment,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :string
 
         attribute :driver_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :editable,
@@ -33,35 +33,35 @@ module Ioki
                   type: :boolean
 
         attribute :punctuality_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :ride_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :ride_version,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :service_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :vehicle_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :vehicle_cleanliness_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :version,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
 
         attribute :waiting_time_rating,
-                  on:   [:create, :read, :update],
+                  on:   :read,
                   type: :integer
       end
     end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1007,46 +1007,6 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#create_rating(product_id, ride_id)' do
-    let(:rating) { Ioki::Model::Operator::Rating.new({ id: '4711' }) }
-
-    it 'calls request on the client with expected params' do
-      expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/rides/4711/rating')
-        [result_with_data, full_response]
-      end
-
-      expect(operator_client.create_rating('0815', rating, options))
-        .to be_a(Ioki::Model::Operator::Rating)
-    end
-  end
-
-  describe '#update_rating(product_id, ride_id, rating)' do
-    let(:rating) { Ioki::Model::Operator::Rating.new({ id: '1337' }) }
-
-    it 'calls request on the client with expected params' do
-      expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/rides/4711/rating/1337')
-        [result_with_data, full_response]
-      end
-
-      expect(operator_client.update_rating('0815', '4711', rating, options))
-        .to be_a(Ioki::Model::Operator::Rating)
-    end
-  end
-
-  describe '#delete_rating(product_id, rating_id)' do
-    it 'calls request on the client with expected params' do
-      expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/rides/4711/rating/1337')
-        result_with_data
-      end
-
-      expect(operator_client.delete_rating('0815', '4711', '1337', options))
-        .to be_a(Ioki::Model::Operator::Rating)
-    end
-  end
-
   describe '#create_position(product_id, vehicle_id, vehicle_position)' do
     let(:vehicle_position) { Ioki::Model::Operator::VehiclePosition.new({ id: '5105' }) }
 


### PR DESCRIPTION
It turns out that the rating endpoints for create/update and delete are deprecated for the operator api and should not be used. This PR will remove the mentioned endpoints.