### PR TITLE
Platform API | Client challenge for phone verification requests

### DIFF
--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -235,6 +235,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'captchas', :id],
         path:        'solution',
         model_class: Ioki::Model::Platform::Captcha
+      ),
+      Endpoints::Create.new(
+        :client_challenge,
+        base_path:   [API_BASE_PATH, 'client_challenges', :id],
+        path:        'solution',
+        model_class: Ioki::Model::Platform::ClientChallenge
       )
     ].freeze
   end

--- a/lib/ioki/model/platform/client_challenge.rb
+++ b/lib/ioki/model/platform/client_challenge.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class ClientChallenge < Base
+        attribute :type, on: :read, type: :string
+        attribute :id, on: :read, type: :string
+        attribute :created_at, on: :read, type: :date_time
+        attribute :updated_at, on: :read, type: :date_time
+        attribute :challenge, on: :read, type: :string
+
+        attribute :solution, on: :create, type: :string
+        attribute :nonce, on: :create, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/phone_verification_request.rb
+++ b/lib/ioki/model/platform/phone_verification_request.rb
@@ -15,6 +15,7 @@ module Ioki
         attribute :phone_number, on: [:read, :create], type: :string
         attribute :locale, on: [:create], type: :string, unvalidated: true
         attribute :captcha, type: :object, on: :read, class_name: 'Captcha'
+        attribute :client_challenge, type: :object, on: :read, class_name: 'ClientChallenge'
       end
     end
   end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -759,4 +759,18 @@ RSpec.describe Ioki::PlatformApi do
         .to eq(Ioki::Model::Platform::Captcha.new)
     end
   end
+
+  describe '#create_client_challenge(id, client_challenge)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/client_challenges/0815/solution')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      client_challenge = Ioki::Model::Platform::ClientChallenge.new(solution: 'w3sd', nonce: '1234')
+      expect(platform_client.create_client_challenge('0815', client_challenge, options))
+        .to eq(Ioki::Model::Platform::ClientChallenge.new)
+    end
+  end
 end


### PR DESCRIPTION
Adds `client_challenge` to phone verification requests.

~~I haven't yet tested it with an actual request, so this is just a draft.~~ I was able to test it now with a real request. It works as expected.