### PR TITLE
Platform Api | Refine UserEmail

### DIFF
--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -44,6 +44,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id],
         model_class: Ioki::Model::Platform::User
       ),
+      Endpoints.custom_endpoints(
+        'user',
+        actions:     { 'email' => :delete },
+        path:        [API_BASE_PATH, 'providers', :id, 'users', :id],
+        model_class: Ioki::Model::Platform::UserEmail
+      ),
       Endpoints.crud_endpoints(
         :driver,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -65,6 +65,7 @@ module Ioki
       attr_accessor :_raw_attributes, :_attributes, :_etag
 
       def initialize(raw_attributes = {}, etag = nil)
+        @_initial_attributes = raw_attributes
         @_raw_attributes = (raw_attributes || {}).transform_keys(&:to_sym)
         @_etag = etag
         reset_attributes!
@@ -147,6 +148,10 @@ module Ioki
           next if definition.key?(:omit_if_blank_on) &&
                   Array(definition[:omit_if_blank_on]).include?(usecase) &&
                   Ioki::Support.blank?(value)
+
+          next if definition.key?(:omit_if_not_provided_on) &&
+                  Array(definition[:omit_if_not_provided_on]).include?(usecase) &&
+                  !@_initial_attributes.key?(attribute)
 
           data[attribute] = if definition[:type] == :object && value.is_a?(Ioki::Model::Base)
                               value.serialize(usecase)

--- a/lib/ioki/model/platform/user_email.rb
+++ b/lib/ioki/model/platform/user_email.rb
@@ -6,10 +6,29 @@ module Ioki
       class UserEmail < Base
         unvalidated true
 
-        attribute :confirmed,     on: :read, type: :boolean
-        attribute :email_address, on: [:create, :read, :update], type: :string
-        attribute :newsletter,    on: [:create, :read, :update], type: :boolean
-        attribute :receipt,       on: [:create, :read, :update], type: :boolean
+        attribute :confirmed,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :confirmed_email_address,
+                  on:   [:create, :update],
+                  type: :string
+
+        attribute :email_address,
+                  on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :newsletter,
+                  on:   [:create, :read, :update],
+                  type: :boolean
+
+        attribute :receipt,
+                  on:   [:create, :read, :update],
+                  type: :boolean
+
+        attribute :unconfirmed_email_address,
+                  on:   [:create, :update],
+                  type: :string
       end
     end
   end

--- a/lib/ioki/model/platform/user_email.rb
+++ b/lib/ioki/model/platform/user_email.rb
@@ -11,12 +11,14 @@ module Ioki
                   type: :boolean
 
         attribute :confirmed_email_address,
-                  on:   [:create, :update],
-                  type: :string
+                  on:                      [:create, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
 
         attribute :email_address,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:                      [:create, :read, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
 
         attribute :newsletter,
                   on:   [:create, :read, :update],
@@ -27,8 +29,9 @@ module Ioki
                   type: :boolean
 
         attribute :unconfirmed_email_address,
-                  on:   [:create, :update],
-                  type: :string
+                  on:                      [:create, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
       end
     end
   end

--- a/spec/ioki/model/platform/user_email_spec.rb
+++ b/spec/ioki/model/platform/user_email_spec.rb
@@ -4,4 +4,53 @@ RSpec.describe Ioki::Model::Platform::UserEmail do
   it { is_expected.to define_attribute(:email_address).as(:string) }
   it { is_expected.to define_attribute(:newsletter).as(:boolean) }
   it { is_expected.to define_attribute(:receipt).as(:boolean) }
+
+  describe 'omit_if_not_provided' do
+    it 'does not serialize omitted attributes' do
+      serialized = described_class.new(
+        confirmed_email_address:   'confirmed@example.com',
+        unconfirmed_email_address: 'unconfirmed@example.com'
+      ).serialize(:create)
+
+      expect(serialized).to eq(
+        {
+          confirmed_email_address:   'confirmed@example.com',
+          unconfirmed_email_address: 'unconfirmed@example.com',
+          newsletter:                nil,
+          receipt:                   nil
+        }
+      )
+    end
+
+    it 'serializes omitted attributes even when they are nil' do
+      serialized = described_class.new(
+        confirmed_email_address:   'confirmed@example.com',
+        unconfirmed_email_address: 'unconfirmed@example.com',
+        email_address:             nil
+      ).serialize(:create)
+
+      expect(serialized).to eq(
+        {
+          confirmed_email_address:   'confirmed@example.com',
+          unconfirmed_email_address: 'unconfirmed@example.com',
+          email_address:             nil,
+          newsletter:                nil,
+          receipt:                   nil
+        }
+      )
+    end
+
+    it 'serializes omitted attributes when the action does not match' do
+      serialized = described_class.new.serialize(:read)
+
+      expect(serialized).to eq(
+        {
+          confirmed:     nil,
+          email_address: nil,
+          newsletter:    nil,
+          receipt:       nil
+        }
+      )
+    end
+  end
 end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -773,4 +773,17 @@ RSpec.describe Ioki::PlatformApi do
         .to eq(Ioki::Model::Platform::ClientChallenge.new)
     end
   end
+
+  describe '#user_delete_email(provider_id, id)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/providers/0815/users/1337/email')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(platform_client.user_email('0815', '1337', options)).
+        to eq(Ioki::Model::Platform::UserEmail.new)
+    end
+  end
 end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -782,8 +782,8 @@ RSpec.describe Ioki::PlatformApi do
         result_with_data
       end
 
-      expect(platform_client.user_email('0815', '1337', options)).
-        to eq(Ioki::Model::Platform::UserEmail.new)
+      expect(platform_client.user_email('0815', '1337', options))
+        .to eq(Ioki::Model::Platform::UserEmail.new)
     end
   end
 end


### PR DESCRIPTION
This PR adds two new attributes (`confirmed_email_address` and `unconfirmed_email_address`) to the UserEmail model for the platform api.

This means, when creating a new user a confirmed or an unconfirmed email address can be send to triebwerk. The attribute `email_address` can still be used but is deprecated now.