### PR TITLE
Change notification settings to new API

### DIFF
--- a/lib/ioki/apis/endpoints/show.rb
+++ b/lib/ioki/apis/endpoints/show.rb
@@ -28,7 +28,12 @@ module Ioki
         # :show can optionally use the model for caching.
         model = options[:model] if options[:model].is_a?(model_class)
         attributes, etag = model_params(client, args, options, model)
-        model_class.new(attributes, etag)
+
+        if model_class == Array
+          attributes
+        else
+          model_class.new(attributes, etag)
+        end
       end
 
       private

--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -93,25 +93,25 @@ module Ioki
         :notification_settings,
         path:        'notification_settings',
         base_path:   [API_BASE_PATH],
-        model_class: Ioki::Model::Passenger::NotificationSettings
+        model_class: Array
       ),
       Endpoints::ShowSingular.new(
         :default_notification_settings,
         path:        %w[passenger notification_settings defaults],
         base_path:   [API_BASE_PATH],
-        model_class: Ioki::Model::Passenger::NotificationSettings
+        model_class: Array
       ),
       Endpoints::ShowSingular.new(
         :available_notification_settings,
         path:        %w[passenger notification_settings available],
         base_path:   [API_BASE_PATH],
-        model_class: Ioki::Model::Passenger::NotificationSettings
+        model_class: Array
       ),
-      Endpoints::UpdateSingular.new(
-        :notification_settings,
-        path:        'notification_settings',
+      Endpoints.crud_endpoints(
+        :notification_setting,
         base_path:   [API_BASE_PATH],
-        model_class: Ioki::Model::Passenger::NotificationSettings
+        model_class: Ioki::Model::Passenger::NotificationSetting,
+        except:      [:index, :show, :create, :delete]
       ),
       Endpoints::Create.new(
         :rating,

--- a/lib/ioki/model/passenger/notification_setting.rb
+++ b/lib/ioki/model/passenger/notification_setting.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class NotificationSetting < Base
+        attribute :id, on: :read, type: :string
+        attribute :type, on: :read, type: :string
+        attribute :name, on: [:read, :update], type: :string
+        attribute :channels, on: [:read, :update], type: :array
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/notification_settings.rb
+++ b/lib/ioki/model/passenger/notification_settings.rb
@@ -4,12 +4,13 @@ module Ioki
   module Model
     module Passenger
       class NotificationSettings < Base
-        attribute :type, on: :read, type: :string
-        attribute :ride_notifications, on: [:read, :update], type: :array
-        attribute :booking_notifications, on: [:read, :update], type: :array
-        attribute :booking_by_operator_notifications, on: [:read, :update], type: :array
-        attribute :payment_notifications, on: [:read, :update], type: :array
-        attribute :referral_notifications, on: [:read, :update], type: :array
+        attribute :root, on: [:read, :update], type: :array
+
+        def serialize(usecase = :read)
+          serialized_data = super(usecase)
+
+          serialized_data[:root]
+        end
       end
     end
   end

--- a/lib/ioki/model/passenger/user.rb
+++ b/lib/ioki/model/passenger/user.rb
@@ -21,7 +21,7 @@ module Ioki
         attribute :failed_payments, on: :read, type: :boolean
         attribute :logpay_customer_set, on: :read, type: :boolean
         attribute :minimum_age_confirmed, on: :read, type: :boolean
-        attribute :notification_settings, on: [:read, :update], type: :object, class_name: 'NotificationSettings'
+        attribute :notification_settings, on: [:read, :update], type: :array
         attribute :referral_code, on: :read, type: :string
         attribute :referring_user_set, on: :read, type: :boolean
         attribute :registered, on: :read, type: :boolean

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Ioki::PassengerApi do
     )
   end
   let(:result_with_data) { instance_double(Hash, 'result double with data', '[]' => {}) }
+  let(:result_with_array_data) { instance_double(Hash, 'result double with data', '[]' => []) }
   let(:result_with_index_data) { instance_double(Hash, 'result double with data', '[]' => [{}]) }
   let(:full_response) { instance_double(Faraday::Response, 'full_response', headers: {}) }
   let(:options) { { options: :example } }
@@ -378,9 +379,19 @@ RSpec.describe Ioki::PassengerApi do
     it 'calls request on the client with expected params' do
       expect(passenger_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('passenger/notification_settings/available')
-        [result_with_data, full_response]
+        [result_with_array_data, full_response]
       end
-      expect(passenger_client.available_notification_settings).to be_a Ioki::Model::Passenger::NotificationSettings
+      expect(passenger_client.available_notification_settings).to be_a Array
+    end
+  end
+
+  describe '#default_notification_settings' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/notification_settings/defaults')
+        [result_with_array_data, full_response]
+      end
+      expect(passenger_client.default_notification_settings).to be_a Array
     end
   end
 


### PR DESCRIPTION
There has been some changes to the notification settings API. This PR accomodates for that.

The old API returned an object, such as:

```ruby
{
  data: {
    ride_notifications: ['sms']
  }
}
```

Now, the API returns an array of `NotificationSetting`:

```ruby
{
  data: [
    {
      id: 'ride_notifications',
      name: 'ride_notifications',
      channels: ['sms']
    }
  ]
}
```