### PR TITLE
Add `omit_if_not_provided_on`

### DIFF
--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -65,6 +65,7 @@ module Ioki
       attr_accessor :_raw_attributes, :_attributes, :_etag
 
       def initialize(raw_attributes = {}, etag = nil)
+        @_initial_attributes = raw_attributes
         @_raw_attributes = (raw_attributes || {}).transform_keys(&:to_sym)
         @_etag = etag
         reset_attributes!
@@ -147,6 +148,10 @@ module Ioki
           next if definition.key?(:omit_if_blank_on) &&
                   Array(definition[:omit_if_blank_on]).include?(usecase) &&
                   Ioki::Support.blank?(value)
+
+          next if definition.key?(:omit_if_not_provided_on) &&
+                  Array(definition[:omit_if_not_provided_on]).include?(usecase) &&
+                  !@_initial_attributes.key?(attribute)
 
           data[attribute] = if definition[:type] == :object && value.is_a?(Ioki::Model::Base)
                               value.serialize(usecase)

--- a/lib/ioki/model/platform/user_email.rb
+++ b/lib/ioki/model/platform/user_email.rb
@@ -11,12 +11,14 @@ module Ioki
                   type: :boolean
 
         attribute :confirmed_email_address,
-                  on:   [:create, :update],
-                  type: :string
+                  on:                      [:create, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
 
         attribute :email_address,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:                      [:create, :read, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
 
         attribute :newsletter,
                   on:   [:create, :read, :update],
@@ -27,8 +29,9 @@ module Ioki
                   type: :boolean
 
         attribute :unconfirmed_email_address,
-                  on:   [:create, :update],
-                  type: :string
+                  on:                      [:create, :update],
+                  type:                    :string,
+                  omit_if_not_provided_on: [:create, :update]
       end
     end
   end

--- a/spec/ioki/model/platform/user_email_spec.rb
+++ b/spec/ioki/model/platform/user_email_spec.rb
@@ -4,4 +4,53 @@ RSpec.describe Ioki::Model::Platform::UserEmail do
   it { is_expected.to define_attribute(:email_address).as(:string) }
   it { is_expected.to define_attribute(:newsletter).as(:boolean) }
   it { is_expected.to define_attribute(:receipt).as(:boolean) }
+
+  describe 'omit_if_not_provided' do
+    it 'does not serialize omitted attributes' do
+      serialized = described_class.new(
+        confirmed_email_address:   'confirmed@example.com',
+        unconfirmed_email_address: 'unconfirmed@example.com'
+      ).serialize(:create)
+
+      expect(serialized).to eq(
+        {
+          confirmed_email_address:   'confirmed@example.com',
+          unconfirmed_email_address: 'unconfirmed@example.com',
+          newsletter:                nil,
+          receipt:                   nil
+        }
+      )
+    end
+
+    it 'serializes omitted attributes even when they are nil' do
+      serialized = described_class.new(
+        confirmed_email_address:   'confirmed@example.com',
+        unconfirmed_email_address: 'unconfirmed@example.com',
+        email_address:             nil
+      ).serialize(:create)
+
+      expect(serialized).to eq(
+        {
+          confirmed_email_address:   'confirmed@example.com',
+          unconfirmed_email_address: 'unconfirmed@example.com',
+          email_address:             nil,
+          newsletter:                nil,
+          receipt:                   nil
+        }
+      )
+    end
+
+    it 'serializes omitted attributes when the action does not match' do
+      serialized = described_class.new.serialize(:read)
+
+      expect(serialized).to eq(
+        {
+          confirmed:     nil,
+          email_address: nil,
+          newsletter:    nil,
+          receipt:       nil
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the property `omit_if_not_provided_on` to attribute definitions.

Example:

```ruby
attribute :confirmed_email_address, omit_if_not_provided_on: [:create], on: [:create, :update]
```

This will then result in:

```ruby
Ioki::Model::Platform::UserEmail.new(confirmed_email_address: 'test@example.com').serialize(:create)
# => { confirmed_email_address: 'test@example.com' }

Ioki::Model::Platform::UserEmail.new.serialize(:create)
# => {}

Ioki::Model::Platform::UserEmail.new.serialize(:update)
# => { confirmed_email_address: nil }
```