### PR TITLE
Add support for bodies other than objects

### DIFF
--- a/lib/ioki/apis/endpoints/show.rb
+++ b/lib/ioki/apis/endpoints/show.rb
@@ -29,11 +29,7 @@ module Ioki
         model = options[:model] if options[:model].is_a?(model_class)
         attributes, etag = model_params(client, args, options, model)
 
-        if model_class == Array
-          attributes
-        else
-          model_class.new(attributes, etag)
-        end
+        model_class.new(attributes, etag)
       end
 
       private

--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -93,19 +93,19 @@ module Ioki
         :notification_settings,
         path:        'notification_settings',
         base_path:   [API_BASE_PATH],
-        model_class: Array
+        model_class: Ioki::Model::Passenger::NotificationSettings
       ),
       Endpoints::ShowSingular.new(
         :default_notification_settings,
         path:        %w[passenger notification_settings defaults],
         base_path:   [API_BASE_PATH],
-        model_class: Array
+        model_class: Ioki::Model::Passenger::NotificationSettings
       ),
       Endpoints::ShowSingular.new(
         :available_notification_settings,
         path:        %w[passenger notification_settings available],
         base_path:   [API_BASE_PATH],
-        model_class: Array
+        model_class: Ioki::Model::Passenger::NotificationSettings
       ),
       Endpoints.crud_endpoints(
         :notification_setting,

--- a/lib/ioki/model/passenger/notification_settings.rb
+++ b/lib/ioki/model/passenger/notification_settings.rb
@@ -4,13 +4,7 @@ module Ioki
   module Model
     module Passenger
       class NotificationSettings < Base
-        attribute :root, on: [:read, :update], type: :array
-
-        def serialize(usecase = :read)
-          serialized_data = super(usecase)
-
-          serialized_data[:root]
-        end
+        base 'Array', item_class_name: 'NotificationSetting'
       end
     end
   end

--- a/spec/ioki/endpoints/show_spec.rb
+++ b/spec/ioki/endpoints/show_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Ioki::Endpoints::Show do
 
     before { model._etag = 'ETAG' }
 
-    it "passes on model'the s etag to the request method via headers" do
+    it "passes on the model's etag to the request method via headers" do
       expect(client).to receive(:request).with(
         url:     url,
         headers: { 'If-None-Match': model._etag },
@@ -50,6 +50,84 @@ RSpec.describe Ioki::Endpoints::Show do
       ).and_return([parsed_data, response])
 
       endpoint.call(client, ['0815'], { model: model, params: params })
+    end
+  end
+
+  context 'with an array based response' do
+    let(:parsed_data) do
+      { 'data' => [{ id: 'ride', name: 'ride', channels: ['sms'], type: 'notification_setting' }] }
+    end
+    let(:response) do
+      instance_double(
+        Faraday::Response,
+        'response double',
+        status:  200,
+        body:    parsed_data,
+        headers: { etag: 'ETAG' }
+      )
+    end
+    let(:endpoint) do
+      described_class.new(
+        'notification_settings',
+        base_path:   ['base'],
+        model_class: Ioki::Model::Passenger::NotificationSettings
+      )
+    end
+
+    it 'parses data and etag' do
+      expect(client).to receive(:request).and_return([parsed_data, response])
+
+      notification_settings = endpoint.call(client, ['0815'])
+
+      expect(notification_settings).to be_a Ioki::Model::Passenger::NotificationSettings
+      expect(notification_settings._etag).to eq 'ETAG'
+      expect(notification_settings._raw_attributes).to eq parsed_data['data']
+      expect(notification_settings.data).to eq [
+        Ioki::Model::Passenger::NotificationSetting.new(
+          id:       'ride',
+          name:     'ride',
+          channels: ['sms'],
+          type:     'notification_setting'
+        )
+      ]
+    end
+  end
+
+  context 'with a string response' do
+    let(:model_class) do
+      Class.new(Ioki::Model::Base) do
+        base 'String'
+      end
+    end
+    let(:parsed_data) do
+      { 'data' => 'test string' }
+    end
+    let(:response) do
+      instance_double(
+        Faraday::Response,
+        'response double',
+        status:  200,
+        body:    parsed_data,
+        headers: { etag: 'ETAG' }
+      )
+    end
+    let(:endpoint) do
+      described_class.new(
+        'example_class',
+        base_path:   ['base'],
+        model_class: model_class
+      )
+    end
+
+    it 'parses data and etag' do
+      expect(client).to receive(:request).and_return([parsed_data, response])
+
+      response = endpoint.call(client, ['0815'])
+
+      expect(response).to be_a model_class
+      expect(response._etag).to eq 'ETAG'
+      expect(response._raw_attributes).to eq parsed_data['data']
+      expect(response.data).to eq 'test string'
     end
   end
 end

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -222,6 +222,7 @@ RSpec.describe Ioki::Model::Base do
           expect(model.foo).to eq('21')
           expect(model._attributes).to eq(foo: '21')
           expect(model._raw_attributes).to eq(foo: 21, baz: 42)
+          expect(model.data).to eq(foo: '21')
         end
       end
     end
@@ -730,6 +731,90 @@ RSpec.describe Ioki::Model::Base do
           expect(model == same_model).to be_truthy
         end
       end
+    end
+  end
+
+  describe 'array body' do
+    let(:example_class) { Ioki::Model::Passenger::NotificationSettings }
+
+    it 'allows an array' do
+      model = example_class.new([])
+
+      expect(model.serialize).to eq []
+    end
+
+    context 'with hash objects in array' do
+      let(:attributes) do
+        [
+          {
+            'id'       => 'ride',
+            'name'     => 'ride',
+            'channels' => %w[sms email],
+            'type'     => 'notification_setting'
+          },
+          {
+            'id'       => 'booking',
+            'name'     => 'booking',
+            'channels' => %w[sms],
+            'type'     => 'notification_setting'
+          }
+        ]
+      end
+
+      it 'parses objects in array' do
+        expect(model.data).to eq [
+          Ioki::Model::Passenger::NotificationSetting.new(
+            id:       'ride',
+            name:     'ride',
+            channels: %w[sms email],
+            type:     'notification_setting'
+          ),
+          Ioki::Model::Passenger::NotificationSetting.new(
+            id:       'booking',
+            name:     'booking',
+            channels: %w[sms],
+            type:     'notification_setting'
+          )
+        ]
+      end
+    end
+
+    it 'serializes objects in array' do
+      model = example_class.new([
+        Ioki::Model::Passenger::NotificationSetting.new(
+          name:     'ride',
+          channels: %w[sms email]
+        ),
+        Ioki::Model::Passenger::NotificationSetting.new(
+          name:     'booking',
+          channels: %w[sms]
+        )
+      ])
+
+      expect(model.serialize(:update)).to eq [
+        {
+          name:     'ride',
+          channels: %w[sms email]
+        },
+        {
+          name:     'booking',
+          channels: %w[sms]
+        }
+      ]
+    end
+  end
+
+  describe 'string body' do
+    let(:example_class) do
+      Class.new(Ioki::Model::Base) do
+        base 'String'
+      end
+    end
+
+    it 'allows a string' do
+      model = example_class.new('test')
+
+      expect(model.serialize).to eq 'test'
     end
   end
 end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe Ioki::PassengerApi do
         expect(params[:url].to_s).to eq('passenger/notification_settings/available')
         [result_with_array_data, full_response]
       end
-      expect(passenger_client.available_notification_settings).to be_a Array
+      expect(passenger_client.available_notification_settings).to be_a Ioki::Model::Passenger::NotificationSettings
     end
   end
 
@@ -391,7 +391,7 @@ RSpec.describe Ioki::PassengerApi do
         expect(params[:url].to_s).to eq('passenger/notification_settings/defaults')
         [result_with_array_data, full_response]
       end
-      expect(passenger_client.default_notification_settings).to be_a Array
+      expect(passenger_client.default_notification_settings).to be_a Ioki::Model::Passenger::NotificationSettings
     end
   end
 


### PR DESCRIPTION
Closes #183.

## TLDR

This adds support for bodies we receive, which are not an object. For example, arrays or plain strings.

Let's say we get the response:

```ruby
{
  data: [
    { name: 'ride_notifications', channels: ['sms'], type: 'notification_setting' }
  ]
}
```

You could now parse this with the following model:

```ruby
class Ioki::Model::Passenger::NotificationSettings
  base 'Array', item_class_name: 'NotificationSetting'
end
```

## Changes

* Up until now all response bodies we parse in ioki-ruby need to be objects (in practice a `Hash`). We now support arrays and basic types (`String`, ..) as well.

  For arrays we need to define an `item_class_name` which specifies the class of the items in the array.
  
  ```ruby
  class Ioki::Model::Passenger::NotificationSettings
    base 'Array', item_class_name: 'NotificationSetting'
  end
  ```
  
  For basic types, we only define the type:
  
  ```ruby
  class Ioki::Model::Passenger::ShuttleColor
    base 'String'
  end
  ```

* Note that even if the response is a basic type or an array, ioki-ruby will always return a model inheriting `Ioki::Model::Base`. This allows for helper methods such as `serialize` and also allows access to the etag using `model._etag`.

  ```ruby
  model = Ioki::Model::Passenger::NotificationSettings.new([{name: 'ride', channels: ['sms']}], 'etag-123')
  
  model._etag
  # => 'etag-123'
  
  model._raw_attributes
  # => [{name: 'ride', channels: ['sms']}]
  # `#_raw_attributes` returns the input value
  
  model.data
  # => [Ioki::Model::Passenger::NotificationSetting<name='ride' channels=['sms']>]
  # `#data` returns the parsed objects
  ```

* New method `#data` which returns the parsed data. For object responses, it returns `#attributes`. The `#data` method should be used in client applications to get the parsed array response.

  ```ruby
  model = Ioki::Model::Passenger::Product.new(name: 'MyProduct')

  model.attributes
  # => {name: 'MyProduct'}

  model.data
  # => {name: 'MyProduct'}
  ```