### PR TITLE
Operator Api | Add more attributes to Vehicle

### DIFF
--- a/lib/ioki/model/operator/image_upload.rb
+++ b/lib/ioki/model/operator/image_upload.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class ImageUpload < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :versions,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'ImageVersion'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/image_upload.rb
+++ b/lib/ioki/model/operator/image_upload.rb
@@ -22,7 +22,7 @@ module Ioki
 
         attribute :versions,
                   on:         :read,
-                  type:       :array,
+                  type:       :object,
                   class_name: 'ImageVersion'
       end
     end

--- a/lib/ioki/model/operator/image_version.rb
+++ b/lib/ioki/model/operator/image_version.rb
@@ -15,7 +15,7 @@ module Ioki
                   type: :string
 
         attribute :small,
-                  on: :read,
+                  on:   :read,
                   type: :string
 
         attribute :mini,

--- a/lib/ioki/model/operator/image_version.rb
+++ b/lib/ioki/model/operator/image_version.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class ImageVersion < Base
+        unvalidated true # Specification not available
+
+        attribute :large,
+                  on:   :read,
+                  type: :string
+
+        attribute :medium,
+                  on:   :read,
+                  type: :string
+
+        attribute :small,
+                  on: :read,
+                  type: :string
+
+        attribute :mini,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -25,6 +25,11 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :boolean
 
+        attribute :avatar,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'ImageUpload'
+
         attribute :connected_driver_id,
                   on:   :read,
                   type: :string
@@ -68,6 +73,11 @@ module Ioki
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],
                   type:           :string
+
+        attribute :num_wheelchair_bays_as_storages,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
 
         attribute :operator_id,
                   on:             [:create, :read, :update],


### PR DESCRIPTION
This PR will add the models `ImageVersion` and `ImageUpload` for the operator api. Other than that, some missing attributes will be added to the `Vehicle` model (`num_wheelchair_bays_as_storages` and `avatar`).