### PR TITLE
Operator Api | Add external_id to Driver model

### DIFF
--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -28,6 +28,11 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :external_id,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
         attribute :first_name,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],


### PR DESCRIPTION
This PR adds some missing attributes to the Driver model.