### PR TITLE
PassengerAPI | Fix updating language

### DIFF
--- a/lib/ioki/apis/endpoints/passenger/update_language.rb
+++ b/lib/ioki/apis/endpoints/passenger/update_language.rb
@@ -10,6 +10,7 @@ module Ioki
 
         def call(client, args = [], options = {})
           client.config.language = args.last
+          client.config.http_adapter = Ioki::HttpAdapter.get(client.config) unless client.config.custom_http_adapter
           client.request(
             url:    client.build_request_url('passenger', 'user', 'language'),
             method: :patch,

--- a/lib/ioki/configuration.rb
+++ b/lib/ioki/configuration.rb
@@ -24,6 +24,7 @@ module Ioki
     ].freeze
 
     attr_accessor(*CONFIG_KEYS)
+    attr_accessor :custom_http_adapter
 
     def initialize(params = {})
       params = DEFAULT_VALUES.merge(params)
@@ -38,6 +39,7 @@ module Ioki
       @language = params[:language]
       # you can pass in a custom Faraday::Connection instance:
       @http_adapter = params[:http_adapter] || Ioki::HttpAdapter.get(self)
+      @custom_http_adapter = !!params[:http_adapter]
     end
 
     def self.from_env(env_prefix = '')
@@ -48,6 +50,7 @@ module Ioki
       CONFIG_KEYS.each do |key|
         send("#{key}=", DEFAULT_VALUES.merge(self.class.values_from_env)[key])
       end
+      @custom_http_adapter = nil
     end
 
     def self.values_from_env(env_prefix = '')

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -5,9 +5,7 @@ require 'spec_helper'
 RSpec.describe Ioki::PassengerApi do
   let(:passenger_client) do
     Ioki::Client.new(
-      instance_double(
-        Ioki::Configuration,
-        :config,
+      Ioki::Configuration.new(
         api_base_url:          'https://app.io.ki/api',
         api_version:           '1',
         api_client_identifier: 'ID',


### PR DESCRIPTION
Currently, the `Passenger#update_language` endpoint doesn't work as expected.

What should happen:

1. Call `my_passenger_client.update_language('fr')`
2. ioki-ruby calls `PATCH /api/passenger/user/language` and sets the `Accept-Language` header to `fr`. That header is used to set the language. There is no body or path parameters.

What actually happens:

1. ioki-ruby is initialized with a `Ioki::Configuration`. At that point the language is taken from the configuration and an HTTP adapter is initialized as `config.http_adapter` with that language.
2. Call `my_passenger_client.update_language('fr')`
3. The method sets `config.language` to the new language and then makes the HTTP request
4. However, the new config has no effect, because the HTTP adapter has been initialised with the initial configuration.

So we have to re-initialize the HTTP adapter, so that the new language takes effect and is sent as the HTTP header.