### PR TITLE
Operator Api | Add `external_id` to Station

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -54,6 +54,11 @@ module Ioki
                   on:   [:read, :create, :update],
                   type: :string
 
+        attribute :external_id,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
         attribute :fixed,
                   on:   :read,
                   type: :boolean


### PR DESCRIPTION
With this PR the attribute `external_id` will be added to the `Station` model for the operator api.