### PR TITLE
Deprecation: Rename driver pin to password

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -36,7 +36,14 @@ module Ioki
       ),
       Endpoints.custom_endpoints(
         'drivers',
-        actions:     { 'lock' => :patch, 'unlock' => :patch, 'regenerate_pin' => :patch, 'set_pin' => :patch },
+        actions:     {
+          'lock'                => :patch,
+          'unlock'              => :patch,
+          'regenerate_pin'      => :patch,
+          'set_pin'             => :patch,
+          'regenerate_password' => :patch,
+          'set_password'        => :patch
+        },
         path:        [API_BASE_PATH, 'products', :id, 'drivers', :id],
         model_class: Ioki::Model::Operator::Driver
       ),

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -39,8 +39,6 @@ module Ioki
         actions:     {
           'lock'                => :patch,
           'unlock'              => :patch,
-          'regenerate_pin'      => :patch,
-          'set_pin'             => :patch,
           'regenerate_password' => :patch,
           'set_password'        => :patch
         },

--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -197,7 +197,12 @@ module Ioki
       ),
       Endpoints.custom_endpoints(
         'drivers',
-        actions:     { 'lock' => :patch, 'unlock' => :patch, 'set_pin' => :patch },
+        actions:     {
+          'lock'         => :patch,
+          'unlock'       => :patch,
+          'set_pin'      => :patch,
+          'set_password' => :patch
+        },
         path:        [API_BASE_PATH, 'products', :id, 'drivers', :id],
         model_class: Ioki::Model::Platform::Driver
       ),

--- a/lib/ioki/model/driver/driver_request_token.rb
+++ b/lib/ioki/model/driver/driver_request_token.rb
@@ -7,6 +7,7 @@ module Ioki
         # The model does not return them but they're used when sending data to the server:
         attribute :username, on: :create, type: :string, unvalidated: true
         attribute :pin, on: :create, type: :string, unvalidated: true
+        attribute :password, on: :create, type: :string, unvalidated: true
         # This is what we care about:
         attribute :token, on: :read, type: :string
         attribute :driver_id, on: :read, type: :string

--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -61,11 +61,6 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :string
 
-        # Deprecated
-        attribute :pin,
-                  on:   :read,
-                  type: :string
-
         attribute :username,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],

--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -53,10 +53,15 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
+        attribute :password,
+                  on:   :read,
+                  type: :string
+
         attribute :phone_number,
                   on:   [:create, :read, :update],
                   type: :string
 
+        # Deprecated
         attribute :pin,
                   on:   :read,
                   type: :string

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -245,6 +245,19 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#drivers_regenerate_password(product_id, driver_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/drivers/4711/regenerate_password')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.drivers_regenerate_password('0815', '4711'))
+        .to be_a(Ioki::Model::Operator::Driver)
+    end
+  end
+
   describe '#drivers_set_pin(product_id, driver_id, pin)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
@@ -254,6 +267,19 @@ RSpec.describe Ioki::OperatorApi do
       end
 
       expect(operator_client.drivers_set_pin('0815', '4711', '123456'))
+        .to be_a(Ioki::Model::Operator::Driver)
+    end
+  end
+
+  describe '#drivers_set_password(product_id, driver_id, password)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/drivers/4711/set_password')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.drivers_set_password('0815', '4711', '123456'))
         .to be_a(Ioki::Model::Operator::Driver)
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -232,19 +232,6 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#drivers_regenerate_pin(product_id, driver_id)' do
-    it 'calls request on the client with expected params' do
-      expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/drivers/4711/regenerate_pin')
-        expect(params[:method]).to eq(:patch)
-        result_with_data
-      end
-
-      expect(operator_client.drivers_regenerate_pin('0815', '4711'))
-        .to be_a(Ioki::Model::Operator::Driver)
-    end
-  end
-
   describe '#drivers_regenerate_password(product_id, driver_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
@@ -254,19 +241,6 @@ RSpec.describe Ioki::OperatorApi do
       end
 
       expect(operator_client.drivers_regenerate_password('0815', '4711'))
-        .to be_a(Ioki::Model::Operator::Driver)
-    end
-  end
-
-  describe '#drivers_set_pin(product_id, driver_id, pin)' do
-    it 'calls request on the client with expected params' do
-      expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/products/0815/drivers/4711/set_pin')
-        expect(params[:method]).to eq(:patch)
-        result_with_data
-      end
-
-      expect(operator_client.drivers_set_pin('0815', '4711', '123456'))
         .to be_a(Ioki::Model::Operator::Driver)
     end
   end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -467,6 +467,18 @@ RSpec.describe Ioki::PlatformApi do
     end
   end
 
+  describe '#drivers_set_password(product_id, driver_id, password)' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/products/0815/drivers/4711/set_password')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(platform_client.drivers_set_password('0815', '4711', '123456')).to be_a(Ioki::Model::Platform::Driver)
+    end
+  end
+
   describe '#create_rating(product_id, ride_id)' do
     let(:rating) { Ioki::Model::Platform::Rating.new({ id: '4711' }) }
 


### PR DESCRIPTION
Closes #191 

This PR will take care of the deprecated attribute `pin`.

Affected namespaces:
### operator api
- custom endpoints renamed
- `pin` removed and `password` added to Driver model

### platform api
- custom endpoint `set_password` added
- `set_pin` is still in place until all clients have applied the required changes

### driver api
- `password` added to `DriverRequestToken` model
- `pin` is still in place until all clients have applied the required changes