### PR TITLE
Operator Api | Add custom endpoint for recalculate

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -79,7 +79,7 @@ module Ioki
       ),
       Endpoints.custom_endpoints(
         'task_lists',
-        actions:     { 'reassign' => :patch },
+        actions:     { 'reassign' => :patch, 'recalculate' => :patch },
         path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
         model_class: Ioki::Model::Operator::TaskList
       ),

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -587,6 +587,19 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#task_lists_reassign(product_id, task_list_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/task_lists/4711/recalculate')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.task_lists_recalculate('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::TaskList)
+    end
+  end
+
   describe '#task_lists_current_journey(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -587,7 +587,7 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#task_lists_reassign(product_id, task_list_id)' do
+  describe '#task_lists_recalculate(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('operator/products/0815/task_lists/4711/recalculate')


### PR DESCRIPTION
This PR will introduce the `recalculate` custom endpoint for the operator api.