### PR TITLE
Let user provide the signature_key to Ioki::Webhooks::SignatureValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,17 @@ webhook `data` as a model:
 
 Because the data is pushed to your application via the internet to a public
 endpoint in your application, the webhook data is signed by the ioki webhooks
-API to authenticate it using a preshared secret, which you need to set as the
-`WEBHOOK_SIGNATURE_KEY` ENV variable.
+API to authenticate it using a preshared secret, which you need to provide.
 
 ```
-# Set ENV['WEBHOOK_SIGNATURE_KEY'] first...
-# Then run the validation on the request:
+# Set ENV['IOKI_WEBHOOK_SIGNATURE_KEY'] first...
+# Then run the validation on the request
 
-Ioki::Webhooks::SignatureValidator.new(body: request.body.read, signature: request.headers['X-Signature']).call
+Ioki::Webhooks::SignatureValidator.new(
+  body:          request.body.read,
+  signature:     request.headers['X-Signature'],
+  signature_key: ENV.fetch('IOKI_WEBHOOK_SIGNATURE_KEY', nil)
+).call
 
 ```
 

--- a/lib/ioki/webhooks/signature_validator.rb
+++ b/lib/ioki/webhooks/signature_validator.rb
@@ -18,7 +18,7 @@ require 'openssl'
 module Ioki
   module Webhooks
     class SignatureValidator
-      def initialize(body:, signature:, signature_key:)
+      def initialize(body:, signature:, signature_key: ENV.fetch('WEBHOOK_SIGNATURE_KEY', nil))
         @body = body
         @signature = signature
         @signature_key = signature_key

--- a/spec/ioki/webhooks/signature_validator_spec.rb
+++ b/spec/ioki/webhooks/signature_validator_spec.rb
@@ -6,7 +6,7 @@ require 'securerandom'
 
 RSpec.describe Ioki::Webhooks::SignatureValidator do
   subject(:validator) do
-    described_class.new signature: signature, body: body
+    described_class.new signature: signature, body: body, signature_key: signature_key
   end
 
   let(:body) do
@@ -24,6 +24,7 @@ RSpec.describe Ioki::Webhooks::SignatureValidator do
   end
   let(:signature) { 'sha256=' + signature_sha256 }
   let(:signature_sha256) { 'NotAnActualSignatureButItHasTheCorrectLengthSoThatsFineAndOkayOK' }
+  let(:signature_key) { 'signature_key' }
 
   context 'when signature is nil' do
     let(:signature) { nil }
@@ -57,33 +58,24 @@ RSpec.describe Ioki::Webhooks::SignatureValidator do
     end
   end
 
-  context 'when the WEBHOOK_SIGNATURE_KEY ENV variable is nil' do
-    before do
-      allow(ENV).to receive(:fetch).with('WEBHOOK_SIGNATURE_KEY', nil).and_return(nil)
-    end
+  context 'when the signature_key is nil' do
+    let(:signature_key) { nil }
 
     it 'raises a Ioki::Error::WebhookSignatureKeyMissing' do
       expect { validator.call }.to raise_error Ioki::Error::WebhookSignatureKeyMissing
     end
   end
 
-  context 'when the WEBHOOK_SIGNATURE_KEY ENV variable is empty' do
-    before do
-      allow(ENV).to receive(:fetch).with('WEBHOOK_SIGNATURE_KEY', nil).and_return('')
-    end
+  context 'when the signature_key is empty' do
+    let(:signature_key) { '' }
 
     it 'raises a Ioki::Error::WebhookSignatureKeyMissing' do
       expect { validator.call }.to raise_error Ioki::Error::WebhookSignatureKeyMissing
     end
   end
 
-  context 'when the WEBHOOK_SIGNATURE_KEY ENV variable is present' do
+  context 'when the signature_key is present' do
     let(:signature_key) { SecureRandom.alphanumeric(24) }
-
-    before do
-      allow(ENV).to receive(:fetch).with(any_args).and_call_original
-      allow(ENV).to receive(:fetch).with('WEBHOOK_SIGNATURE_KEY', nil).and_return(signature_key)
-    end
 
     it 'raises a Ioki::Error::WebhookSignatureInvalid' do
       expect { validator.call }.to raise_error Ioki::Error::WebhookSignatureInvalid


### PR DESCRIPTION
There is no need to define how the signature key is set. In our case the ENV is a bad choice. This PR fixes that...