### PR TITLE
Add support for bleeding edge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ initializer you could do it like this:
       cfg.api_base_url          = 'https://demo.io.ki/api/'
       cfg.api_client_identifier = 'com.ioki.example.client'
       cfg.api_client_version    = '0.0.1'
+      cfg.api_bleeding_edge     = false
 
       # As you should not put secrets into your source code, you probably want
       # to NOT use these:
@@ -109,6 +110,7 @@ and api_client_secret. You can setup these ENV variables:
   ENV['IOKI_API_CLIENT_SECRET']
   ENV['IOKI_API_CLIENT_VERSION']
   ENV['IOKI_API_TOKEN']
+  ENV['IOKI_API_BLEEDING_EDGE']
 ```
 
 or define them for one of the three supported apis with a prefix:

--- a/lib/ioki/configuration.rb
+++ b/lib/ioki/configuration.rb
@@ -4,10 +4,11 @@ module Ioki
   class Configuration
     DEFAULT_VALUES =
       {
-        api_base_url:   'https://app.io.ki/api/',
-        api_version:    '20210101',
-        language:       'de',
-        logger_options: { headers: true, bodies: false, log_level: :info }
+        api_base_url:      'https://app.io.ki/api/',
+        api_version:       '20210101',
+        api_bleeding_edge: false,
+        language:          'de',
+        logger_options:    { headers: true, bodies: false, log_level: :info }
       }.freeze
 
     CONFIG_KEYS = [
@@ -20,6 +21,7 @@ module Ioki
       :api_client_secret,
       :api_client_version,
       :api_token,
+      :api_bleeding_edge,
       :language
     ].freeze
 
@@ -36,6 +38,7 @@ module Ioki
       @api_client_secret = params[:api_client_secret]
       @api_client_version = params[:api_client_version]
       @api_token = params[:api_token]
+      @api_bleeding_edge = params[:api_bleeding_edge]
       @language = params[:language]
       # you can pass in a custom Faraday::Connection instance:
       @http_adapter = params[:http_adapter] || Ioki::HttpAdapter.get(self)
@@ -62,7 +65,8 @@ module Ioki
         api_client_identifier: ENV.fetch("#{prefix}_API_CLIENT_IDENTIFIER", nil),
         api_client_secret:     ENV.fetch("#{prefix}_API_CLIENT_SECRET", nil),
         api_client_version:    ENV.fetch("#{prefix}_API_CLIENT_VERSION", nil),
-        api_token:             ENV.fetch("#{prefix}_API_TOKEN", nil)
+        api_token:             ENV.fetch("#{prefix}_API_TOKEN", nil),
+        api_bleeding_edge:     ENV.fetch("#{prefix}_API_BLEEDING_EDGE", nil)&.downcase == 'true'
       }.reject { |_key, value| value.nil? || value.to_s == '' }
     end
   end

--- a/lib/ioki/http_adapter.rb
+++ b/lib/ioki/http_adapter.rb
@@ -39,6 +39,7 @@ module Ioki
         'Accept-Language'     => config.language.to_s,
         # api_headers
         'X-Api-Version'       => config.api_version,
+        'X-Bleeding-Edge'     => config.api_bleeding_edge ? 'true' : nil,
         # client_headers
         'X-Client-Identifier' => config.api_client_identifier,
         'X-Client-Secret'     => config.api_client_secret,

--- a/spec/ioki/configuration_spec.rb
+++ b/spec/ioki/configuration_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Ioki::Configuration do
       :api_client_secret,
       :api_client_version,
       :api_token,
+      :api_bleeding_edge,
       :language
     )
   end
@@ -51,6 +52,7 @@ RSpec.describe Ioki::Configuration do
           api_client_secret:     nil,
           api_client_version:    nil,
           api_token:             nil,
+          api_bleeding_edge:     false,
           language:              'de',
           logger_options:        described_class::DEFAULT_VALUES[:logger_options]
         }.freeze
@@ -90,7 +92,8 @@ RSpec.describe Ioki::Configuration do
         'IOKI_API_CLIENT_IDENTIFIER' => 'CLIENT_IDENTIFIER',
         'IOKI_API_CLIENT_SECRET'     => 'CLIENT_SECRET',
         'IOKI_API_CLIENT_VERSION'    => 'CLIENT_VERSION',
-        'IOKI_API_TOKEN'             => 'API_TOKEN'
+        'IOKI_API_TOKEN'             => 'API_TOKEN',
+        'IOKI_API_BLEEDING_EDGE'     => 'true'
       )
 
       config_from_env = described_class.from_env
@@ -101,6 +104,7 @@ RSpec.describe Ioki::Configuration do
       expect(config_from_env.api_client_secret).to eq 'CLIENT_SECRET'
       expect(config_from_env.api_client_version).to eq 'CLIENT_VERSION'
       expect(config_from_env.api_token).to eq 'API_TOKEN'
+      expect(config_from_env.api_bleeding_edge).to be true
     end
   end
 end

--- a/spec/ioki/http_adapter_spec.rb
+++ b/spec/ioki/http_adapter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Ioki::HttpAdapter do
       api_client_secret:     SecureRandom.alphanumeric,
       api_client_version:    'api_client_version',
       api_token:             SecureRandom.alphanumeric,
+      api_bleeding_edge:     false,
       language:              :'en-BZ',
       logger:                logger,
       logger_options:        { headers: true, bodies: true }
@@ -59,6 +60,7 @@ RSpec.describe Ioki::HttpAdapter do
     it { is_expected.to include 'X-Client-Identifier' => config.api_client_identifier }
     it { is_expected.to include 'X-Client-Secret'     => config.api_client_secret }
     it { is_expected.to include 'X-Client-Version'    => config.api_client_version }
+    it { is_expected.not_to include 'X-Bleeding-Edge' => config.api_bleeding_edge }
     it { is_expected.to include 'Authorization'       => "Bearer #{config.api_token}" }
 
     context 'when there is a header without a value' do
@@ -67,6 +69,14 @@ RSpec.describe Ioki::HttpAdapter do
       end
 
       it { is_expected.not_to include 'X-Client-Identifier' }
+    end
+
+    context 'when bleeding edge is set' do
+      before do
+        config.api_bleeding_edge = true
+      end
+
+      it { is_expected.to include 'X-Bleeding-Edge' => config.api_bleeding_edge.to_s }
     end
   end
 


### PR DESCRIPTION
This adds support for the "bleeding edge" API version.

It defaults to `false` by default. You can either configure it using `Ioki.config.api_bleeding_edge` or using the environment variable `IOKI_API_BLEEDING_EDGE`.