### PR TITLE
Remove configuration to test the default

### DIFF
--- a/spec/ioki/http_adapter_spec.rb
+++ b/spec/ioki/http_adapter_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Ioki::HttpAdapter do
       api_client_secret:     SecureRandom.alphanumeric,
       api_client_version:    'api_client_version',
       api_token:             SecureRandom.alphanumeric,
-      api_bleeding_edge:     false,
       language:              :'en-BZ',
       logger:                logger,
       logger_options:        { headers: true, bodies: true }


### PR DESCRIPTION
Remove explicit configuration in the spec to test the default behavior (cf. https://github.com/ioki-mobility/ioki-ruby/pull/213#discussion_r1169804043).