### PR TITLE
Operator Api | Add more attributes to Place model

### DIFF
--- a/lib/ioki/model/operator/place.rb
+++ b/lib/ioki/model/operator/place.rb
@@ -73,9 +73,9 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :string
 
-        atribute :waiting_position,
-                 on:   [:read, :create, :update],
-                 type: :boolean
+        attribute :waiting_position,
+                  on:   [:read, :create, :update],
+                  type: :boolean
 
         attribute :version,
                   on:   :read,

--- a/lib/ioki/model/operator/place.rb
+++ b/lib/ioki/model/operator/place.rb
@@ -32,6 +32,10 @@ module Ioki
                   on:   [:read, :create, :update],
                   type: :string
 
+        attribute :depot,
+                  on:   [:read, :create, :update],
+                  type: :boolean
+
         attribute :description,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],
@@ -68,6 +72,10 @@ module Ioki
         attribute :street_number,
                   on:   [:create, :read, :update],
                   type: :string
+
+        atribute :waiting_position,
+                 on:   [:read, :create, :update],
+                 type: :boolean
 
         attribute :version,
                   on:   :read,


### PR DESCRIPTION
This will add `depot` and `waiting_position` to the place model for the operator api.