### PR TITLE
Operator API | Add `line_id` to tasks lists

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -117,6 +117,11 @@ module Ioki
                   on:             [:create, :read, :reassign],
                   omit_if_nil_on: [:create, :reassign],
                   type:           :string
+
+        attribute :line_id,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
       end
     end
   end


### PR DESCRIPTION
This allows to associate lines to task lists.