### PR TITLE
Setup omit_if_nil_on to version

### DIFF
--- a/lib/ioki/model/operator/deactivation.rb
+++ b/lib/ioki/model/operator/deactivation.rb
@@ -31,8 +31,9 @@ module Ioki
                   type:           :date_time
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/driver.rb
+++ b/lib/ioki/model/operator/driver.rb
@@ -67,8 +67,9 @@ module Ioki
                   type:           :string
 
         attribute :version,
-                  on:   [:update, :read],
-                  type: :integer
+                  on:             [:update, :read],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/matching_configuration.rb
+++ b/lib/ioki/model/operator/matching_configuration.rb
@@ -170,8 +170,9 @@ module Ioki
                   type: :integer
 
         attribute :version,
-                  on:   [:update, :read],
-                  type: :integer
+                  on:             [:update, :read],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/pause.rb
+++ b/lib/ioki/model/operator/pause.rb
@@ -62,8 +62,9 @@ module Ioki
                   type:           :date_time
 
         attribute :version,
-                  on:   [:update, :read],
-                  type: :integer
+                  on:             [:update, :read],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/place.rb
+++ b/lib/ioki/model/operator/place.rb
@@ -80,8 +80,9 @@ module Ioki
                   type:           :boolean
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -109,8 +109,9 @@ module Ioki
                   type:           :array
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
 
         attribute :walker_boarding_time,
                   on:   [:read, :create, :update],

--- a/lib/ioki/model/operator/station_category.rb
+++ b/lib/ioki/model/operator/station_category.rb
@@ -36,8 +36,9 @@ module Ioki
                   type:           :string
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -124,8 +124,9 @@ module Ioki
                   type:           :string
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/user.rb
+++ b/lib/ioki/model/operator/user.rb
@@ -71,8 +71,9 @@ module Ioki
                   type: :date_time
 
         attribute :version,
-                  on:   [:read, :update],
-                  type: :integer
+                  on:             [:read, :update],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -109,8 +109,9 @@ module Ioki
                   type:           :integer
 
         attribute :version,
-                  on:   [:update, :read],
-                  type: :integer
+                  on:             [:update, :read],
+                  omit_if_nil_on: [:update],
+                  type:           :integer
       end
     end
   end


### PR DESCRIPTION
Apparently, updating some resources result in 422 at the moment. Reason being that when no value for version is set `nil` will be send in to triebwerk which produces problems.