### PR TITLE
Operator Api | Add area and area_geojson to Station model

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -24,6 +24,15 @@ module Ioki
                   on:   :read,
                   type: :boolean
 
+        attribute :area,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Geojson'
+
+        attribute :area_geojson,
+                  on:   [:create, :update],
+                  type: :string
+
         attribute :boarding_time,
                   on:   [:read, :create, :update],
                   type: :integer


### PR DESCRIPTION
This PR will add `area` and `area_geojson` to the station model.