### PR TITLE
Define class_name for notification_settings in User model

### DIFF
--- a/lib/ioki/model/operator/user.rb
+++ b/lib/ioki/model/operator/user.rb
@@ -58,8 +58,9 @@ module Ioki
                   type: :date_time
 
         attribute :notification_settings,
-                  on:   :read,
-                  type: :array
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'NotificationSetting'
 
         attribute :phone_number,
                   on:               [:read, :create, :update],


### PR DESCRIPTION
At the moment, the notification settings for users consist of hashes not objects. 
This PR will make sure that the notification settings will return an array of NotificationSetting objects.