### PR TITLE
Passenger API | Fix omitting `nil` values for ride rating

### DIFF
--- a/lib/ioki/model/passenger/rating.rb
+++ b/lib/ioki/model/passenger/rating.rb
@@ -10,13 +10,13 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :version, on: :read, type: :integer
         attribute :comment, on: [:read, :create], type: :string
-        attribute :driver_rating, on: [:read, :create], type: :integer
+        attribute :driver_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
         attribute :editable, on: :read, type: :boolean
-        attribute :punctuality_rating, on: [:read, :create], type: :integer
-        attribute :ride_rating, on: [:read, :create], type: :integer
-        attribute :service_rating, on: [:read, :create], type: :integer
-        attribute :vehicle_rating, on: [:read, :create], type: :integer
-        attribute :waiting_time_rating, on: [:read, :create], type: :integer
+        attribute :punctuality_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
+        attribute :ride_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
+        attribute :service_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
+        attribute :vehicle_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
+        attribute :waiting_time_rating, on: [:read, :create], type: :integer, omit_if_nil_on: :create
         attribute :ride_version, on: :create, type: :integer
       end
     end


### PR DESCRIPTION
This fixes `nil` values for ride ratings not being sent to the API. If you do, this will result in validation errors:

```
{"api_errors"=>[{"message"=>"Validation failed", "code"=>"validation_failed"}],
 "debug_information"=>
  {"schema_errors"=>
    ["#/driver_rating: fails type(:integer) validation",
     "#/service_rating: fails type(:integer) validation",
     "#/vehicle_rating: fails type(:integer) validation"]}}
```