### PR TITLE
Add `visible_on_map_in_passenger_client` to station model

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -122,6 +122,10 @@ module Ioki
                   omit_if_nil_on: [:update],
                   type:           :integer
 
+        attribute :visible_on_map_in_passenger_client,
+                  on:   :read
+                  type: :boolean
+
         attribute :walker_boarding_time,
                   on:   [:read, :create, :update],
                   type: :integer

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -123,7 +123,7 @@ module Ioki
                   type:           :integer
 
         attribute :visible_on_map_in_passenger_client,
-                  on:   :read
+                  on:   :read,
                   type: :boolean
 
         attribute :walker_boarding_time,


### PR DESCRIPTION
This PR will add the attribute `visible_on_map_in_passenger_client` to the Station model