### PR TITLE
Fix `area_geojson` not to be sent when `nil`

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -30,8 +30,9 @@ module Ioki
                   class_name: 'Geojson'
 
         attribute :area_geojson,
-                  on:   [:create, :update],
-                  type: :string
+                  on:             [:create, :update],
+                  type:           :string,
+                  omit_if_nil_on: [:create, :update]
 
         attribute :boarding_time,
                   on:   [:read, :create, :update],


### PR DESCRIPTION
If it is `nil`, the API returns a `422` as it only accepts strings (but not `nil`).