### PR TITLE
Operator Api | Add vehicle_plannings endpoint for operator api

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -88,6 +88,11 @@ module Ioki
         base_path:   [API_BASE_PATH, 'products', :id, 'task_lists'],
         model_class: Ioki::Model::Operator::TaskList
       ),
+      Endpoints::Index.new(
+        :vehicle_plannings,
+        base_path:   [API_BASE_PATH, 'products', :id, 'task_lists'],
+        model_class: Ioki::Model::Operator::TaskList
+      ),
       Endpoints.custom_endpoints(
         'task_lists',
         actions:     { 'current_journey' => :get },

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -624,6 +624,18 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#vehicle_plannings(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/task_lists/vehicle_plannings')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.vehicle_plannings('0815', options))
+        .to all(be_a(Ioki::Model::Operator::TaskList))
+    end
+  end
+
   describe '#pauses(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
This PR will add the new endpoint `vehicle_plannings` for the operator api.