### PR TITLE
Operator Api | Add `matching_rank` to Operator, Vehicle and TaskList model

### DIFF
--- a/lib/ioki/model/operator/operator.rb
+++ b/lib/ioki/model/operator/operator.rb
@@ -28,6 +28,10 @@ module Ioki
                   on:   :read,
                   type: :boolean
 
+        attribute :matching_rank,
+                  on:   :read,
+                  type: :integer
+
         attribute :name,
                   on:   [:create, :read, :update],
                   type: :string

--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -65,6 +65,10 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :string
 
+        attribute :matching_rank,
+                  on:   :read,
+                  type: :integer
+
         attribute :paused,
                   on:   :read,
                   type: :boolean

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -69,6 +69,10 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :string
 
+        attribute :matching_rank,
+                  on:   :read,
+                  type: :integer
+
         attribute :model,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],


### PR DESCRIPTION
This PR will add the attribute `matching_rank` to the Operator, Vehicle and TaskList model for the operator api.