### PR TITLE
Platform API | Change to remove newsletter and receipt from user email if not provided

### DIFF
--- a/lib/ioki/model/platform/user_email.rb
+++ b/lib/ioki/model/platform/user_email.rb
@@ -21,12 +21,14 @@ module Ioki
                   omit_if_not_provided_on: [:create, :update]
 
         attribute :newsletter,
-                  on:   [:create, :read, :update],
-                  type: :boolean
+                  on:                      [:create, :read, :update],
+                  omit_if_not_provided_on: [:create, :update],
+                  type:                    :boolean
 
         attribute :receipt,
-                  on:   [:create, :read, :update],
-                  type: :boolean
+                  on:                      [:create, :read, :update],
+                  omit_if_not_provided_on: [:create, :update],
+                  type:                    :boolean
 
         attribute :unconfirmed_email_address,
                   on:                      [:create, :update],

--- a/spec/ioki/model/platform/user_email_spec.rb
+++ b/spec/ioki/model/platform/user_email_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe Ioki::Model::Platform::UserEmail do
       expect(serialized).to eq(
         {
           confirmed_email_address:   'confirmed@example.com',
-          unconfirmed_email_address: 'unconfirmed@example.com',
-          newsletter:                nil,
-          receipt:                   nil
+          unconfirmed_email_address: 'unconfirmed@example.com'
         }
       )
     end
@@ -33,9 +31,7 @@ RSpec.describe Ioki::Model::Platform::UserEmail do
         {
           confirmed_email_address:   'confirmed@example.com',
           unconfirmed_email_address: 'unconfirmed@example.com',
-          email_address:             nil,
-          newsletter:                nil,
-          receipt:                   nil
+          email_address:             nil
         }
       )
     end


### PR DESCRIPTION
If newsletter and receipt are set as `nil` the API returns a validation error that they are not booleans. We therefore omit them if they are not provided.