### PR TITLE
Operator Api: add admin_sign_out endpoint for the operator api

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -220,6 +220,12 @@ module Ioki
         path:                 'repositioning_tasks',
         model_class:          Ioki::Model::Operator::Task,
         outgoing_model_class: Ioki::Model::Operator::RepositioningTask
+      ),
+      Endpoints.custom_endpoints(
+        'admin',
+        actions:     { 'sign_out' => :delete },
+        path:        [API_BASE_PATH, 'admin'],
+        model_class: Ioki::Model::Operator::Admin
       )
     ].freeze
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1239,4 +1239,17 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Task)
     end
   end
+
+  describe '#admin_sign_out' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/admin/sign_out')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.admin_sign_out)
+        .to be_a(Ioki::Model::Operator::Admin)
+    end
+  end
 end


### PR DESCRIPTION
This adds an endpoint for signing out the admin via the operator api.