### PR TITLE
Remove unnecessary WebMock enabling/disabling

### DIFF
--- a/spec/ioki/oauth/with_token_refresh_spec.rb
+++ b/spec/ioki/oauth/with_token_refresh_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'ioki/apis/endpoints/endpoints'
-require 'webmock'
 
 class PingApi
   ENDPOINTS =
@@ -16,19 +15,7 @@ class PingApi
 end
 
 RSpec.describe Ioki::Oauth::WithTokenRefresh do
-  include WebMock::API
-
   let(:client) { Ioki::Client.new(config, PingApi) }
-
-  before do
-    WebMock.enable!
-    VCR.turn_off!
-  end
-
-  after do
-    WebMock.disable!
-    VCR.turn_on!
-  end
 
   context 'with oauth configuration' do
     let(:config) do

--- a/spec/ioki/retry_spec.rb
+++ b/spec/ioki/retry_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'ioki/apis/endpoints/endpoints'
-require 'webmock'
 
 class DummyApi
   ENDPOINTS =
@@ -16,8 +15,6 @@ class DummyApi
 end
 
 RSpec.describe Ioki::Retry do
-  include WebMock::API
-
   it 'executes the given block' do
     called = false
 
@@ -77,16 +74,6 @@ RSpec.describe Ioki::Retry do
 
   context 'with a Ioki client' do
     let(:client) { Ioki::Client.new(Ioki::Configuration.new, DummyApi) }
-
-    before do
-      WebMock.enable!
-      VCR.turn_off!
-    end
-
-    after do
-      WebMock.disable!
-      VCR.turn_on!
-    end
 
     it 'retries failed requests' do
       ping_request = stub_request(:get, 'https://app.io.ki/api/driver/ping')


### PR DESCRIPTION
This caused issues with other specs, as WebMock should be enabled anyways for VCR to work (with our configuration).

Before this fix, although `bundle exec rspec` worked fine, `bundle exec rspec --order rand` did not.

With this (unnecessary) code removed, even randomized test runs now work fine.