### PR TITLE
Operator Api | Add overview endpoint for stations

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -67,6 +67,11 @@ module Ioki
         path:        [API_BASE_PATH, 'products', :id, 'stations', :id],
         model_class: Ioki::Model::Operator::Station
       ),
+      Endpoints::Index.new(
+        :overview,
+        base_path:   [API_BASE_PATH, 'products', :id, 'stations'],
+        model_class: Ioki::Model::Operator::Station
+      ),
       Endpoints.crud_endpoints(
         :matching_configuration,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -68,8 +68,9 @@ module Ioki
         model_class: Ioki::Model::Operator::Station
       ),
       Endpoints::Index.new(
-        :overview,
+        :station_overview,
         base_path:   [API_BASE_PATH, 'products', :id, 'stations'],
+        path:        'overview',
         model_class: Ioki::Model::Operator::Station
       ),
       Endpoints.crud_endpoints(

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -98,7 +98,7 @@ module Ioki
 
         attribute :station_category_id,
                   on:   [:create, :update, :read],
-                  type: :string.
+                  type: :string
 
         attribute :station_category_slug,
                   on:   :read,

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -98,6 +98,10 @@ module Ioki
 
         attribute :station_category_id,
                   on:   [:create, :update, :read],
+                  type: :string.
+
+        attribute :station_category_slug,
+                  on:   :read,
                   type: :string
 
         attribute :station_type,

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -432,6 +432,18 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#overview(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/overview')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.overview('0815', options))
+        .to all(be_a(Ioki::Model::Operator::Station))
+    end
+  end
+
   describe '#matching_configurations(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -432,14 +432,14 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#overview(product_id)' do
+  describe '#station_overview(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('operator/products/0815/stations/overview')
         [result_with_data, full_response]
       end
 
-      expect(operator_client.overview('0815', options))
+      expect(operator_client.station_overview('0815', options))
         .to all(be_a(Ioki::Model::Operator::Station))
     end
   end


### PR DESCRIPTION
This PR will add the `overview` endpoint for stations which will return a small subset of all station attributes.