### PR TITLE
Operator Api | Put User endpoints in product scope

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -210,7 +210,7 @@ module Ioki
       ),
       Endpoints.crud_endpoints(
         :user,
-        base_path:   [API_BASE_PATH, 'providers', :id],
+        base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::User,
         except:      [:create, :update, :delete]
       ),

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1202,10 +1202,10 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#users(provider_id)' do
+  describe '#users(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/providers/0815/users')
+        expect(params[:url].to_s).to eq('operator/products/0815/users')
         result_with_index_data
       end
 
@@ -1214,10 +1214,10 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#user(provider_id, user_id)' do
+  describe '#user(product_id, user_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
-        expect(params[:url].to_s).to eq('operator/providers/0815/users/4711')
+        expect(params[:url].to_s).to eq('operator/products/0815/users/4711')
         [result_with_data, full_response]
       end
 


### PR DESCRIPTION
This PR will fix the `base_path` for the user endpoints for the operator api.