### PR TITLE
Operator Api: add missing attributes to Area model

### DIFF
--- a/lib/ioki/model/operator/area.rb
+++ b/lib/ioki/model/operator/area.rb
@@ -4,6 +4,22 @@ module Ioki
   module Model
     module Operator
       class Area < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :
+                  
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+                  
         attribute :name,
                   type:           :string,
                   on:             [:create, :read, :update],


### PR DESCRIPTION
This PR will add some missing attributes to the Area model for the operator api.