### PR TITLE
Operator Api | add user autocomplete

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -218,7 +218,7 @@ module Ioki
         'users',
         actions:     { 'autocomplete' => :get },
         path:        [API_BASE_PATH, 'providers', :id, 'users'],
-        model_class: Ioki::Model::Operator::UserAutocomplete
+        model_class: Ioki::Model::Operator::UserAutocompletes
       ),
       Endpoints::Create.new(
         :ride_inquiry,

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -214,6 +214,12 @@ module Ioki
         model_class: Ioki::Model::Operator::User,
         except:      [:create, :update, :delete]
       ),
+      Endpoitns.custom_endpoints(
+        'users',
+        actions:     { 'autocomplete' => :get },
+        path:        [API_BASE_PATH, 'providers', :id, 'users'],
+        model_class: Ioki::Model::Operator::UserAutocomplete
+      ),
       Endpoints::Create.new(
         :ride_inquiry,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -214,7 +214,7 @@ module Ioki
         model_class: Ioki::Model::Operator::User,
         except:      [:create, :update, :delete]
       ),
-      Endpoitns.custom_endpoints(
+      Endpoints.custom_endpoints(
         'users',
         actions:     { 'autocomplete' => :get },
         path:        [API_BASE_PATH, 'providers', :id, 'users'],

--- a/lib/ioki/model/operator/user_autocomplete.rb
+++ b/lib/ioki/model/operator/user_autocomplete.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class UserAutocomplete < Base
+        attribute :value,
+                  on:   :read,
+                  type: :string
+
+        attribute :label,
+                  on:   :read,
+                  type: :string
+
+        attribute :locked,
+                  on:   :read,
+                  type: :boolean
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/user_autocompletes.rb
+++ b/lib/ioki/model/operator/user_autocompletes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class UserAutocompletes < Base
+        base 'Array', item_class_name: 'UserAutocomplete'
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1253,4 +1253,17 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Task)
     end
   end
+
+  describe '#users_autocomplete(provider_id, ...)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/users/autocomplete')
+        expect(params[:method]).to eq(:get)
+        result_with_data
+      end
+
+      expect(operator_client.users_autocomplete('0815', options))
+        .to be_a(Ioki::Model::Operator::UserAutocomplete)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1263,7 +1263,7 @@ RSpec.describe Ioki::OperatorApi do
       end
 
       expect(operator_client.users_autocomplete('0815', options))
-        .to be_a(Ioki::Model::Operator::UserAutocomplete)
+        .to be_a(Ioki::Model::Operator::UserAutocompletes)
     end
   end
 end


### PR DESCRIPTION
This PR will add the endpoint `autocomplete` for the user resource.