### PR TITLE
Add matching modes to line stops

### DIFF
--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -10,6 +10,8 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :tier, on: [:read, :create, :update], type: :integer
         attribute :relative_time, on: [:read, :create, :update], type: :integer
+        attribute :dropoff_mode, on: [:read, :create, :update], type: :string
+        attribute :pickup_mode, on: [:read, :create, :update], type: :string
         attribute :supports_pickup, on: [:read, :create, :update], type: :boolean
         attribute :supports_dropoff, on: [:read, :create, :update], type: :boolean
         attribute :supports_pass_through, on: [:read, :create, :update], type: :boolean

--- a/lib/ioki/model/platform/line_stop.rb
+++ b/lib/ioki/model/platform/line_stop.rb
@@ -10,6 +10,8 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :tier, on: [:read, :create, :update], type: :integer
         attribute :relative_time, on: [:read, :create, :update], type: :integer
+        attribute :dropoff_mode, on: [:read, :create, :update], type: :string
+        attribute :pickup_mode, on: [:read, :create, :update], type: :string
         attribute :supports_pickup, on: [:read, :create, :update], type: :boolean
         attribute :supports_dropoff, on: [:read, :create, :update], type: :boolean
         attribute :supports_pass_through, on: [:read, :create, :update], type: :boolean


### PR DESCRIPTION
This adds the matching modes `dropoff_mode` and `pickup_mode` to the line stops.