### PR TITLE
Add `omit_if_nil_on` to matching mode attributes

### DIFF
--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -10,8 +10,8 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :tier, on: [:read, :create, :update], type: :integer
         attribute :relative_time, on: [:read, :create, :update], type: :integer
-        attribute :dropoff_mode, on: [:read, :create, :update], type: :string
-        attribute :pickup_mode, on: [:read, :create, :update], type: :string
+        attribute :dropoff_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
+        attribute :pickup_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
         attribute :supports_pickup, on: [:read, :create, :update], type: :boolean
         attribute :supports_dropoff, on: [:read, :create, :update], type: :boolean
         attribute :supports_pass_through, on: [:read, :create, :update], type: :boolean

--- a/lib/ioki/model/platform/line_stop.rb
+++ b/lib/ioki/model/platform/line_stop.rb
@@ -10,8 +10,8 @@ module Ioki
         attribute :updated_at, on: :read, type: :date_time
         attribute :tier, on: [:read, :create, :update], type: :integer
         attribute :relative_time, on: [:read, :create, :update], type: :integer
-        attribute :dropoff_mode, on: [:read, :create, :update], type: :string
-        attribute :pickup_mode, on: [:read, :create, :update], type: :string
+        attribute :dropoff_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
+        attribute :pickup_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
         attribute :supports_pickup, on: [:read, :create, :update], type: :boolean
         attribute :supports_dropoff, on: [:read, :create, :update], type: :boolean
         attribute :supports_pass_through, on: [:read, :create, :update], type: :boolean


### PR DESCRIPTION
Because `dropoff_mode` and `pickup_mode` are optional attributes, we should not send them if they are `nil`.