### PR TITLE
Passenger API | Payment details

### DIFF
--- a/lib/ioki/model/passenger/payment_method_details.rb
+++ b/lib/ioki/model/passenger/payment_method_details.rb
@@ -4,8 +4,8 @@ module Ioki
   module Model
     module Passenger
       class PaymentMethodDetails < Base
-        attribute :braintree_nonce, on: :create, type: :string
-        attribute :paypal_secure_element, on: :create, type: :string
+        attribute :braintree_nonce, on: :create, type: :string, omit_if_nil_on: :create
+        attribute :paypal_secure_element, on: :create, type: :string, omit_if_nil_on: :create
         attribute :stripe_payment_method_id, on: :create, type: :string, omit_if_nil_on: :create
       end
     end

--- a/lib/ioki/model/passenger/payment_method_details.rb
+++ b/lib/ioki/model/passenger/payment_method_details.rb
@@ -6,6 +6,7 @@ module Ioki
       class PaymentMethodDetails < Base
         attribute :braintree_nonce, on: :create, type: :string
         attribute :paypal_secure_element, on: :create, type: :string
+        attribute :stripe_payment_method_id, on: :create, type: :string, omit_if_nil_on: :create
       end
     end
   end


### PR DESCRIPTION
This changes:

- Add `stripe_payment_method_id` to be able to create stripe payment methods
- Change other payment method details not to be sent when `nil`. Otherwise the server side validation fails.