### PR TITLE
Passenger API | Add stripe setup intent

### DIFF
--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -192,6 +192,12 @@ module Ioki
         model_class:          Ioki::Model::Passenger::Tip,
         outgoing_model_class: Ioki::Model::Passenger::TipCreate
       ),
+      Endpoints.custom_endpoints(
+        :stripe,
+        actions:     { 'setup_intent' => :post },
+        path:        [API_BASE_PATH, 'payment_methods'],
+        model_class: Ioki::Model::Passenger::StripeSetupIntent
+      ),
       Endpoints::Passenger::UpdateLanguage.new
     ].freeze
   end

--- a/lib/ioki/model/passenger/stripe_setup_intent.rb
+++ b/lib/ioki/model/passenger/stripe_setup_intent.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class StripeSetupIntent < Base
+        attribute :id, on: :read, type: :string
+        attribute :client_secret, on: :read, type: :string
+        attribute :type, on: :read, type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -448,4 +448,16 @@ RSpec.describe Ioki::PassengerApi do
         .to be_a Ioki::Model::Passenger::PaymentMethod
     end
   end
+
+  describe '#stripe_setup_intent' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/payment_methods/setup_intent')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.stripe_setup_intent)
+        .to be_a Ioki::Model::Passenger::StripeSetupIntent
+    end
+  end
 end


### PR DESCRIPTION
This allows to create a "setup intent" for Stripe.