### PR TITLE
Operator Api | Add missing product feature flag

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -142,6 +142,10 @@ module Ioki
                   type: :boolean,
                   on:   :read
 
+        attribute :passenger_client_displays_stations_on_map,
+                  type: :boolean,
+                  on:   :read
+
         attribute :auto_accept_by_driver_client,
                   type: :boolean,
                   on:   :read

--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -142,10 +142,6 @@ module Ioki
                   type: :boolean,
                   on:   :read
 
-        attribute :passenger_client_displays_stations_on_map,
-                  type: :boolean,
-                  on:   :read
-
         attribute :auto_accept_by_driver_client,
                   type: :boolean,
                   on:   :read

--- a/lib/ioki/model/operator/product.rb
+++ b/lib/ioki/model/operator/product.rb
@@ -72,6 +72,10 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :displays_stations_on_map,
+                  type: :boolean,
+                  on:   :read
+
         attribute :features,
                   on:         :read,
                   type:       :object,

--- a/spec/ioki/model/operator/product_spec.rb
+++ b/spec/ioki/model/operator/product_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Product do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+  it { is_expected.to define_attribute(:version).as(:integer) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:provider).as(:object).with(class_name: 'Provider') }
+  it { is_expected.to define_attribute(:area).as(:object).with(class_name: 'Geojson') }
+  it { is_expected.to define_attribute(:ad_hoc_bookable).as(:boolean) }
+  it { is_expected.to define_attribute(:boarding_time).as(:integer) }
+  it { is_expected.to define_attribute(:bounding_box).as(:object).with(class_name: 'BoundingBox') }
+  it { is_expected.to define_attribute(:default_end_place_id).as(:string) }
+  it { is_expected.to define_attribute(:default_matching_configuration).as(:object).with(class_name: 'MatchingConfiguration') }
+  it { is_expected.to define_attribute(:default_service_duration).as(:integer) }
+  it { is_expected.to define_attribute(:default_service_start).as(:integer) }
+  it { is_expected.to define_attribute(:default_start_place_id).as(:string) }
+  it { is_expected.to define_attribute(:description).as(:string) }
+  it { is_expected.to define_attribute(:displays_stations_on_map).as(:boolean) }
+  it { is_expected.to define_attribute(:features).as(:object).with(class_name: 'Features') }
+  it { is_expected.to define_attribute(:fixed_stations).as(:array).with(class_name: 'Station') }
+  it { is_expected.to define_attribute(:matching_configurations).as(:array).with(class_name: 'MatchingConfiguration') }
+  it { is_expected.to define_attribute(:parking_time).as(:integer) }
+  it { is_expected.to define_attribute(:prebookable).as(:boolean) }
+  it { is_expected.to define_attribute(:ride_options).as(:object).with(class_name: 'RideOptions') }
+  it { is_expected.to define_attribute(:ride_rating_criteria).as(:array) }
+  it { is_expected.to define_attribute(:service_time_info).as(:string) }
+  it { is_expected.to define_attribute(:state).as(:string) }
+  it { is_expected.to define_attribute(:timezone).as(:object).with(class_name: 'Timezone') }
+  it { is_expected.to define_attribute(:walker_boarding_time).as(:integer) }
+  it { is_expected.to define_attribute(:wheelchair_boarding_time).as(:integer) }
+end

--- a/spec/ioki/model/operator/product_spec.rb
+++ b/spec/ioki/model/operator/product_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe Ioki::Model::Operator::Product do
   it { is_expected.to define_attribute(:boarding_time).as(:integer) }
   it { is_expected.to define_attribute(:bounding_box).as(:object).with(class_name: 'BoundingBox') }
   it { is_expected.to define_attribute(:default_end_place_id).as(:string) }
-  it { is_expected.to define_attribute(:default_matching_configuration).as(:object).with(class_name: 'MatchingConfiguration') }
+
+  it {
+    is_expected.to define_attribute(:default_matching_configuration).as(:object)
+      .with(class_name: 'MatchingConfiguration')
+  }
+
   it { is_expected.to define_attribute(:default_service_duration).as(:integer) }
   it { is_expected.to define_attribute(:default_service_start).as(:integer) }
   it { is_expected.to define_attribute(:default_start_place_id).as(:string) }


### PR DESCRIPTION
This PR will add the missing feature flag `:passenger_client_displays_stations_on_map` to the `Features` model.