### PR TITLE
Remove the `operator_id` from update

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -89,8 +89,8 @@ module Ioki
                   type:           :integer
 
         attribute :operator_id,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
+                  on:             [:create, :read],
+                  omit_if_nil_on: [:create],
                   type:           :string
 
         attribute :phone_number,

--- a/lib/ioki/model/platform/vehicle.rb
+++ b/lib/ioki/model/platform/vehicle.rb
@@ -62,8 +62,8 @@ module Ioki
                   type: :string
 
         attribute :operator_id,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
+                  on:             [:create, :read],
+                  omit_if_nil_on: [:create],
                   type:           :string
 
         attribute :phone_number,


### PR DESCRIPTION
The operator can only be set when creating a vehicle, but not when updating. This is valid for the operator and the platform API.