### PR TITLE
Add `payment_method_on_booking` to passenger and platform API

### DIFF
--- a/lib/ioki/model/passenger/product.rb
+++ b/lib/ioki/model/passenger/product.rb
@@ -19,6 +19,8 @@ module Ioki
         attribute :cancellation_statements, on: :read, type: :array, class_name: 'CancellationStatement'
         attribute :description, on: :read, type: :string
         attribute :fixed_stations, on: :read, type: :array, class_name: 'Station'
+        attribute :payment_method_allowed_on_booking, on: :read, type: :boolean
+        attribute :payment_method_required_on_booking, on: :read, type: :boolean
         attribute :personal_discount_types, on: :read, type: :array, class_name: 'PersonalDiscountType'
         attribute :phone_number, on: :read, type: :string
         attribute :prebookable, on: :read, type: :boolean

--- a/lib/ioki/model/platform/product.rb
+++ b/lib/ioki/model/platform/product.rb
@@ -21,6 +21,8 @@ module Ioki
         attribute :ride_options, on: :read, type: :object, class_name: 'RideOptions'
         attribute :passenger_options, on: :read, type: :array, class_name: 'PassengerOption'
         attribute :passenger_types, on: :read, type: :array, class_name: 'PassengerType'
+        attribute :payment_method_allowed_on_booking, on: :read, type: :boolean
+        attribute :payment_method_required_on_booking, on: :read, type: :boolean
         attribute :product_ride_options, on: :read, type: :array, class_name: 'RideOption'
         attribute :ride_rating_criteria, on: :read, type: :array
         attribute :service_time_info, on: :read, type: :string


### PR DESCRIPTION
Adds two more attributes to the `Product` model.