### PR TITLE
CRUD endpoints | Fix `except` option and add `only` option

### DIFF
--- a/lib/ioki/apis/endpoints/endpoints.rb
+++ b/lib/ioki/apis/endpoints/endpoints.rb
@@ -38,12 +38,11 @@ module Ioki
 
         type_key = type.to_s.split('::').last.downcase.to_sym
         name = [Index].include?(type) ? plural : singular
-        action_name = type.to_s.split('::').last.downcase.to_sym
 
         create_action = if only
-                          only.include?(action_name)
+                          only.include?(type_key)
                         elsif except
-                          !except.include?(action_name)
+                          !except.include?(type_key)
                         else
                           true
                         end

--- a/lib/ioki/apis/endpoints/endpoints.rb
+++ b/lib/ioki/apis/endpoints/endpoints.rb
@@ -21,7 +21,7 @@ module Ioki
       plural = "#{resource}s"
       singular = resource.to_s
 
-      [Index, Show, Create, Update, Delete].map do |type|
+      [Index, Show, Create, Update, Delete].filter_map do |type|
         # In some cases endpoints are not consistently using singular and plural for the same type of endpoints. In that
         # case or similar ones an endpoints path can be forced. The logic here allows to express this for
         # `crud_endpoints`.
@@ -34,8 +34,9 @@ module Ioki
 
         type_key = type.to_s.split('::').last.downcase.to_sym
         name = [Index].include?(type) ? plural : singular
+        action_name = type.to_s.split('::').last.downcase.to_sym
 
-        unless except&.include?(type.class.to_s.downcase)
+        unless except&.include?(action_name)
           type.new(name, model_class: model_class, base_path: base_path, path: paths[type_key])
         end
       end

--- a/spec/ioki/endpoints_spec.rb
+++ b/spec/ioki/endpoints_spec.rb
@@ -60,5 +60,24 @@ RSpec.describe Ioki::Endpoints do
         ]
       end
     end
+
+    context 'with `only`' do
+      let(:arguments) { { only: [:index, :create] } }
+
+      it 'filters actions not included in `only`' do
+        expect(subject).to match_array [
+          kind_of(Ioki::Endpoints::Index),
+          kind_of(Ioki::Endpoints::Create)
+        ]
+      end
+    end
+
+    context 'with invalid options' do
+      let(:arguments) { { only: [:index], except: [:show] } }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error ArgumentError
+      end
+    end
   end
 end

--- a/spec/ioki/endpoints_spec.rb
+++ b/spec/ioki/endpoints_spec.rb
@@ -38,4 +38,27 @@ RSpec.describe Ioki::Endpoints do
       end
     end
   end
+
+  describe '.crud_endpoints' do
+    subject do
+      described_class.crud_endpoints(
+        :rides,
+        base_path:   ['/api'],
+        model_class: Ioki::Model::Platform::Ride,
+        **arguments
+      )
+    end
+
+    context 'with `except`' do
+      let(:arguments) { { except: [:index, :create] } }
+
+      it 'filters actions included in `except`' do
+        expect(subject).to match_array [
+          kind_of(Ioki::Endpoints::Show),
+          kind_of(Ioki::Endpoints::Update),
+          kind_of(Ioki::Endpoints::Delete)
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes the `except` option when passed to `Endpoints.crud_endpoints`. The problem was that we didn't correctly deduce the action name (e.g. `:index`) from the action classes (e.g. `Ioki::Endpoints::Index`).

Mainly because `type` was e.g. `Ioki::Endpoints::Index`, but then calling `type.class` results in `Class` (because `type` is already a constant). So we checked whether the passed in *symbols* are equal to the string `"class"`, which never was true, hence the `except` option didn't have any effect.

Additionally, this PR adds an `only` option. If you only need 2 actions, it's easier to specify it as `only` instead of `except`.