### PR TITLE
Rename feature flag

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -42,7 +42,7 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'], response.headers[:etag])
+        model_class.new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
       end
     end
   end

--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -33,7 +33,7 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'])
+        model_class.new(parsed_response['data'], nil, show_deprecation_warnings: false)
       end
     end
   end

--- a/lib/ioki/apis/endpoints/endpoint.rb
+++ b/lib/ioki/apis/endpoints/endpoint.rb
@@ -27,7 +27,7 @@ module Ioki
         )
 
         if model_class
-          model_class.new(parsed_response['data'])
+          model_class.new(parsed_response['data'], nil, show_deprecation_warnings: false)
         else
           parsed_response
         end

--- a/lib/ioki/apis/endpoints/index.rb
+++ b/lib/ioki/apis/endpoints/index.rb
@@ -74,7 +74,11 @@ module Ioki
           params: options[:params]
         )
 
-        [parsed_response['data'].map { |attr| model_class.new(attr) }, parsed_response, response]
+        [
+          parsed_response['data'].map { |attr| model_class.new(attr, nil, show_deprecation_warnings: false) },
+          parsed_response,
+          response
+        ]
       end
     end
   end

--- a/lib/ioki/apis/endpoints/show.rb
+++ b/lib/ioki/apis/endpoints/show.rb
@@ -29,7 +29,7 @@ module Ioki
         model = options[:model] if options[:model].is_a?(model_class)
         attributes, etag = model_params(client, args, options, model)
 
-        model_class.new(attributes, etag)
+        model_class.new(attributes, etag, show_deprecation_warnings: false)
       end
 
       private

--- a/lib/ioki/apis/endpoints/update.rb
+++ b/lib/ioki/apis/endpoints/update.rb
@@ -41,7 +41,7 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'], response.headers[:etag])
+        model_class.new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
       end
     end
   end

--- a/lib/ioki/configuration.rb
+++ b/lib/ioki/configuration.rb
@@ -4,14 +4,14 @@ module Ioki
   class Configuration
     DEFAULT_VALUES =
       {
-        api_base_url:        'https://app.io.ki/api/',
-        api_version:         '20210101',
-        api_bleeding_edge:   false,
-        language:            'de',
-        logger_options:      { headers: true, bodies: false, log_level: :info },
-        retry_count:         3,
-        retry_sleep_seconds: 1,
-        filter_deprecated:   false
+        api_base_url:                 'https://app.io.ki/api/',
+        api_version:                  '20210101',
+        api_bleeding_edge:            false,
+        language:                     'de',
+        logger_options:               { headers: true, bodies: false, log_level: :info },
+        retry_count:                  3,
+        retry_sleep_seconds:          1,
+        ignore_deprecated_attributes: false
       }.freeze
 
     CONFIG_KEYS = [
@@ -34,7 +34,7 @@ module Ioki
       :oauth_token_callback,
       :retry_count,
       :retry_sleep_seconds,
-      :filter_deprecated
+      :ignore_deprecated_attributes
     ].freeze
 
     attr_accessor(*CONFIG_KEYS)
@@ -60,7 +60,7 @@ module Ioki
       @oauth_token_callback = params[:oauth_token_callback]
       @retry_count = params[:retry_count]
       @retry_sleep_seconds = params[:retry_sleep_seconds]
-      @filter_deprecated = params[:filter_deprecated]
+      @ignore_deprecated_attributes = params[:ignore_deprecated_attributes]
       # you can pass in a custom Faraday::Connection instance:
       @http_adapter = params[:http_adapter] || Ioki::HttpAdapter.get(self)
       @custom_http_adapter = !!params[:http_adapter]
@@ -81,19 +81,19 @@ module Ioki
       prefix = ['IOKI', env_prefix].reject(&:empty?).join('_')
 
       {
-        api_base_url:          ENV.fetch("#{prefix}_API_BASE_URL", nil),
-        api_version:           ENV.fetch("#{prefix}_API_VERSION", nil),
-        api_client_identifier: ENV.fetch("#{prefix}_API_CLIENT_IDENTIFIER", nil),
-        api_client_secret:     ENV.fetch("#{prefix}_API_CLIENT_SECRET", nil),
-        api_client_version:    ENV.fetch("#{prefix}_API_CLIENT_VERSION", nil),
-        api_token:             ENV.fetch("#{prefix}_API_TOKEN", nil),
-        api_bleeding_edge:     ENV.fetch("#{prefix}_API_BLEEDING_EDGE", nil)&.downcase == 'true',
-        oauth_app_id:          ENV.fetch("#{prefix}_OAUTH_APP_ID", nil),
-        oauth_app_secret:      ENV.fetch("#{prefix}_OAUTH_APP_SECRET", nil),
-        oauth_app_url:         ENV.fetch("#{prefix}_OAUTH_APP_URL", nil),
-        retry_count:           ENV.fetch("#{prefix}_RETRY_COUNT", nil),
-        retry_sleep_seconds:   ENV.fetch("#{prefix}_RETRY_SLEEP_SECONDS", nil),
-        filter_deprecated:     ENV.fetch("#{prefix}_FILTER_DEPRECATED", nil)
+        api_base_url:                 ENV.fetch("#{prefix}_API_BASE_URL", nil),
+        api_version:                  ENV.fetch("#{prefix}_API_VERSION", nil),
+        api_client_identifier:        ENV.fetch("#{prefix}_API_CLIENT_IDENTIFIER", nil),
+        api_client_secret:            ENV.fetch("#{prefix}_API_CLIENT_SECRET", nil),
+        api_client_version:           ENV.fetch("#{prefix}_API_CLIENT_VERSION", nil),
+        api_token:                    ENV.fetch("#{prefix}_API_TOKEN", nil),
+        api_bleeding_edge:            ENV.fetch("#{prefix}_API_BLEEDING_EDGE", nil)&.downcase == 'true',
+        oauth_app_id:                 ENV.fetch("#{prefix}_OAUTH_APP_ID", nil),
+        oauth_app_secret:             ENV.fetch("#{prefix}_OAUTH_APP_SECRET", nil),
+        oauth_app_url:                ENV.fetch("#{prefix}_OAUTH_APP_URL", nil),
+        retry_count:                  ENV.fetch("#{prefix}_RETRY_COUNT", nil),
+        retry_sleep_seconds:          ENV.fetch("#{prefix}_RETRY_SLEEP_SECONDS", nil),
+        ignore_deprecated_attributes: ENV.fetch("#{prefix}_IGNORE_DEPRECATED_ATTRIBUTES", nil)
       }.reject { |_key, value| value.nil? || value.to_s == '' }
     end
 

--- a/lib/ioki/configuration.rb
+++ b/lib/ioki/configuration.rb
@@ -10,7 +10,8 @@ module Ioki
         language:            'de',
         logger_options:      { headers: true, bodies: false, log_level: :info },
         retry_count:         3,
-        retry_sleep_seconds: 1
+        retry_sleep_seconds: 1,
+        filter_deprecated:   false
       }.freeze
 
     CONFIG_KEYS = [
@@ -32,7 +33,8 @@ module Ioki
       :oauth_refresh_token,
       :oauth_token_callback,
       :retry_count,
-      :retry_sleep_seconds
+      :retry_sleep_seconds,
+      :filter_deprecated
     ].freeze
 
     attr_accessor(*CONFIG_KEYS)
@@ -58,6 +60,7 @@ module Ioki
       @oauth_token_callback = params[:oauth_token_callback]
       @retry_count = params[:retry_count]
       @retry_sleep_seconds = params[:retry_sleep_seconds]
+      @filter_deprecated = params[:filter_deprecated]
       # you can pass in a custom Faraday::Connection instance:
       @http_adapter = params[:http_adapter] || Ioki::HttpAdapter.get(self)
       @custom_http_adapter = !!params[:http_adapter]
@@ -89,7 +92,8 @@ module Ioki
         oauth_app_secret:      ENV.fetch("#{prefix}_OAUTH_APP_SECRET", nil),
         oauth_app_url:         ENV.fetch("#{prefix}_OAUTH_APP_URL", nil),
         retry_count:           ENV.fetch("#{prefix}_RETRY_COUNT", nil),
-        retry_sleep_seconds:   ENV.fetch("#{prefix}_RETRY_SLEEP_SECONDS", nil)
+        retry_sleep_seconds:   ENV.fetch("#{prefix}_RETRY_SLEEP_SECONDS", nil),
+        filter_deprecated:     ENV.fetch("#{prefix}_FILTER_DEPRECATED", nil)
       }.reject { |_key, value| value.nil? || value.to_s == '' }
     end
 

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -120,7 +120,7 @@ module Ioki
       end
 
       def attributes_without_deprecated
-        if Ioki.config.filter_deprecated
+        if Ioki.config.ignore_deprecated_attributes
           @_attributes.reject { |attribute, _value| self.class.attribute_definitions[attribute][:deprecated] }
         else
           @_attributes
@@ -186,7 +186,7 @@ module Ioki
 
           next unless Array(definition[:on]).include?(usecase)
 
-          next if Ioki.config.filter_deprecated && definition[:deprecated]
+          next if Ioki.config.ignore_deprecated_attributes && definition[:deprecated]
 
           next if definition.key?(:omit_if_nil_on) &&
                   Array(definition[:omit_if_nil_on]).include?(usecase) &&

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -287,7 +287,12 @@ module Ioki
       end
 
       def deprecated_attribute_message(attribute)
-        "The attribute `#{self.class.name}##{attribute}` is deprecated."
+        attribute_message = "The attribute `#{self.class.name}##{attribute}` is deprecated."
+
+        replaced_by = self.class.class_instance_attribute_definitions.dig(attribute, :replaced_by)
+        replaced_by_message = " Please use `#{self.class.name}##{replaced_by}` instead." if replaced_by
+
+        "#{attribute_message}#{replaced_by_message}"
       end
 
       def attribute_deprecated?(attribute)

--- a/lib/ioki/model/passenger/personal_discount_type.rb
+++ b/lib/ioki/model/passenger/personal_discount_type.rb
@@ -28,9 +28,8 @@ module Ioki
         attribute :payment_method, on: :create, type: :object, class_name: 'PaymentMethod'
         attribute :paypal_secure_element, on: :create, type: :string, omit_if_blank: true
 
-        # Deprecated
-        attribute :absolute_discount_object, on: :read, type: :object, class_name: 'Money'
-        attribute :price_object, on: :read, type: :object, class_name: 'Money'
+        deprecated_attribute :absolute_discount_object, on: :read, type: :object, class_name: 'Money'
+        deprecated_attribute :price_object, on: :read, type: :object, class_name: 'Money'
       end
     end
   end

--- a/lib/ioki/model/platform/product_features.rb
+++ b/lib/ioki/model/platform/product_features.rb
@@ -6,7 +6,10 @@ module Ioki
       class ProductFeatures < Base
         unvalidated true # Specification not available
 
-        deprecated_attribute :supports_multiple_booking_solutions, type: :boolean, on: :read
+        deprecated_attribute :supports_multiple_booking_solutions,
+                             type:        :boolean,
+                             on:          :read,
+                             replaced_by: :multiple_booking_solutions
         attribute :multiple_booking_solutions, type: :boolean, on: :read
         attribute :station_search, type: :boolean, on: :read
       end

--- a/lib/ioki/model/platform/product_features.rb
+++ b/lib/ioki/model/platform/product_features.rb
@@ -7,6 +7,7 @@ module Ioki
         unvalidated true # Specification not available
 
         attribute :supports_multiple_booking_solutions, type: :boolean, on: :read
+        attribute :multiple_booking_solutions, type: :boolean, on: :read
         attribute :station_search, type: :boolean, on: :read
       end
     end

--- a/lib/ioki/model/platform/product_features.rb
+++ b/lib/ioki/model/platform/product_features.rb
@@ -6,7 +6,7 @@ module Ioki
       class ProductFeatures < Base
         unvalidated true # Specification not available
 
-        attribute :supports_multiple_booking_solutions, type: :boolean, on: :read
+        deprecated_attribute :supports_multiple_booking_solutions, type: :boolean, on: :read
         attribute :multiple_booking_solutions, type: :boolean, on: :read
         attribute :station_search, type: :boolean, on: :read
       end

--- a/lib/ioki/webhooks/event.rb
+++ b/lib/ioki/webhooks/event.rb
@@ -7,7 +7,7 @@ module Ioki
     class Event < OpenStruct
 
       def model
-        model_class.new data
+        model_class.new(data, nil, show_deprecation_warnings: false)
       end
 
       def model_class

--- a/spec/ioki/configuration_spec.rb
+++ b/spec/ioki/configuration_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Ioki::Configuration do
       :oauth_token_callback,
       :retry_count,
       :retry_sleep_seconds,
-      :filter_deprecated
+      :ignore_deprecated_attributes
     )
   end
 
@@ -55,18 +55,18 @@ RSpec.describe Ioki::Configuration do
       stub_const(
         'EXPECTED_DEFAULTS',
         {
-          api_base_url:          described_class::DEFAULT_VALUES[:api_base_url],
-          api_version:           described_class::DEFAULT_VALUES[:api_version],
-          api_client_identifier: nil,
-          api_client_secret:     nil,
-          api_client_version:    nil,
-          api_token:             nil,
-          api_bleeding_edge:     false,
-          language:              'de',
-          logger_options:        described_class::DEFAULT_VALUES[:logger_options],
-          retry_count:           3,
-          retry_sleep_seconds:   1,
-          filter_deprecated:     false
+          api_base_url:                 described_class::DEFAULT_VALUES[:api_base_url],
+          api_version:                  described_class::DEFAULT_VALUES[:api_version],
+          api_client_identifier:        nil,
+          api_client_secret:            nil,
+          api_client_version:           nil,
+          api_token:                    nil,
+          api_bleeding_edge:            false,
+          language:                     'de',
+          logger_options:               described_class::DEFAULT_VALUES[:logger_options],
+          retry_count:                  3,
+          retry_sleep_seconds:          1,
+          ignore_deprecated_attributes: false
         }.freeze
       )
     end

--- a/spec/ioki/configuration_spec.rb
+++ b/spec/ioki/configuration_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Ioki::Configuration do
       :oauth_refresh_token,
       :oauth_token_callback,
       :retry_count,
-      :retry_sleep_seconds
+      :retry_sleep_seconds,
+      :filter_deprecated
     )
   end
 
@@ -64,7 +65,8 @@ RSpec.describe Ioki::Configuration do
           language:              'de',
           logger_options:        described_class::DEFAULT_VALUES[:logger_options],
           retry_count:           3,
-          retry_sleep_seconds:   1
+          retry_sleep_seconds:   1,
+          filter_deprecated:     false
         }.freeze
       )
     end

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -872,6 +872,7 @@ RSpec.describe Ioki::Model::Base do
     let(:example_class) do
       Class.new(Ioki::Model::Base) do
         deprecated_attribute :name, type: :string, on: [:read, :create]
+        deprecated_attribute :identifier, type: :string, on: [:read, :create], replaced_by: :slug
         attribute :slug, type: :string, on: [:read, :create]
       end
     end
@@ -882,6 +883,8 @@ RSpec.describe Ioki::Model::Base do
 
         expect { model.name }.to output("The attribute `#name` is deprecated.\n").to_stderr
         expect { model.name = 'new name' }.to output("The attribute `#name` is deprecated.\n").to_stderr
+        expect { model.identifier }
+          .to output("The attribute `#identifier` is deprecated. Please use `#slug` instead.\n").to_stderr
       end
 
       it 'does not warn when the attribute is not deprecated' do

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -866,4 +866,41 @@ RSpec.describe Ioki::Model::Base do
       expect(model.serialize).to eq 'test'
     end
   end
+
+  describe 'deprecated attributes' do
+    let(:attributes) { { name: 'FastCar', slug: 'FastCar' } }
+    let(:example_class) do
+      Class.new(Ioki::Model::Base) do
+        deprecated_attribute :name, type: :string, on: [:read, :create]
+        attribute :slug, type: :string, on: [:read, :create]
+      end
+    end
+
+    describe 'when accessing attributes' do
+      it 'warns when the attribute is deprecated' do
+        model = example_class.new(attributes)
+
+        expect { model.name }.to output("The attribute `#name` is deprecated.\n").to_stderr
+        expect { model.name = 'new name' }.to output("The attribute `#name` is deprecated.\n").to_stderr
+      end
+
+      it 'does not warn when the attribute is not deprecated' do
+        model = example_class.new(attributes)
+
+        expect { model.slug }.not_to output.to_stderr
+        expect { model.slug = 'new slug' }.not_to output.to_stderr
+      end
+    end
+
+    describe 'when initializing a model' do
+      it 'warns when initializing with deprecated attributes' do
+        expect { example_class.new(name: 'I am deprecated!') }
+          .to output("The attribute `#name` is deprecated.\n").to_stderr
+      end
+
+      it 'does not warn when initializing without deprecated attributes' do
+        expect { example_class.new(slug: 'A slug') }.not_to output.to_stderr
+      end
+    end
+  end
 end


### PR DESCRIPTION
`supports_multiple_booking_solutions` is deprecated in favor of `multiple_booking_solutions`.

This might be breaking, but I doubt that anyone is already using it. And we haven't yet released 1.0 😀