### PR TITLE
Operator Api | Add matching logs endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -238,6 +238,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id, 'users'],
         path:        'autocomplete',
         model_class: Ioki::Model::Operator::User
+      ),
+      Endpoints::Index.new(
+        :ride_matching_log,
+        base_path:   [API_BASE_PATH, 'products', :id, 'rides', :id],
+        path:        'matching_logs',
+        model_class: Ioki::Model::Operator::MatchingLog
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/matching_log.rb
+++ b/lib/ioki/model/operator/matching_log.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class MatchingLog < Base
+        attribute :dt,
+                  on:   :read,
+                  type: :integer
+
+        attribute :log_level,
+                  on:   :read,
+                  type: :integer
+
+        attribute :message,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/model/operator/matching_log_spec.rb
+++ b/spec/ioki/model/operator/matching_log_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::MatchingLog do
+  it { is_expected.to define_attribute(:dt).as(:integer) }
+  it { is_expected.to define_attribute(:log_level).as(:integer) }
+  it { is_expected.to define_attribute(:message).as(:string) }
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1277,4 +1277,16 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::User))
     end
   end
+
+  describe '#ride_matching_log(product_id, ride_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/rides/01/matching_logs')
+        result_with_index_data
+      end
+
+      expect(operator_client.ride_matching_log('0815', '01', options))
+        .to all(be_a(Ioki::Model::Operator::MatchingLog))
+    end
+  end
 end


### PR DESCRIPTION
This will add the endpoint for retrieving ride matching logs.