### PR TITLE
Operator Api | Ride Notification

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -238,6 +238,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id, 'users'],
         path:        'autocomplete',
         model_class: Ioki::Model::Operator::User
+      ),
+      Endpoints::Index.new(
+        :rides_notifications,
+        base_path:   [API_BASE_PATH, 'products', :id, 'rides', :id],
+        path:        'notifications',
+        model_class: Ioki::Model::Operator::Notification
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/notification.rb
+++ b/lib/ioki/model/operator/notification.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Notification < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :body,
+                  on:   :read,
+                  type: :string
+
+        attribute :body_for_sms,
+                  on:   :read,
+                  type: :string
+
+        attribute :channels,
+                  on:   :read,
+                  type: :array
+
+        attribute :delivered_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :notification_type,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/model/operator/notification_spec.rb
+++ b/spec/ioki/model/operator/notification_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Notification do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+  it { is_expected.to define_attribute(:body).as(:string) }
+  it { is_expected.to define_attribute(:body_for_sms).as(:string) }
+  it { is_expected.to define_attribute(:channels).as(:array) }
+  it { is_expected.to define_attribute(:delivered_at).as(:date_time) }
+  it { is_expected.to define_attribute(:notification_type).as(:string) }
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1277,4 +1277,16 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::User))
     end
   end
+
+  describe '#rides_notifications(product_id, ride_id, ...)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/rides/01/notifications')
+        result_with_index_data
+      end
+
+      expect(operator_client.rides_notifications('0815', '01', options))
+        .to all(be_a(Ioki::Model::Operator::Notification))
+    end
+  end
 end


### PR DESCRIPTION
This PR will introduce the ride notification model for the operator api. Also the `rides_notifications` endpoint will be added which can be used to retrieve all notifications that are connected to a specific ride.