### PR TITLE
Operator Api | Add translated_ride_cancellation_reasons

### DIFF
--- a/lib/ioki/model/operator/cancellation_reason_with_translations.rb
+++ b/lib/ioki/model/operator/cancellation_reason_with_translations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class CancellationReasonWithTranslations < Base
+        attribute :slug,
+                  on:   :read,
+                  type: :string
+
+        attribute :translations,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'MultilanguageString'
+
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/multilanguage_string.rb
+++ b/lib/ioki/model/operator/multilanguage_string.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class MultilanguageString < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :name,
+                  on:   :read,
+                  type: :string
+
+        attribute :translations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Translation'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/product.rb
+++ b/lib/ioki/model/operator/product.rb
@@ -121,6 +121,11 @@ module Ioki
                   type:       :object,
                   class_name: 'Timezone'
 
+        attribute :translated_ride_cancellation_reasons,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'CancellationReasonWithTranslations'
+
         attribute :version,
                   on:   :read,
                   type: :integer

--- a/lib/ioki/model/operator/translation.rb
+++ b/lib/ioki/model/operator/translation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Translation < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :language,
+                  on:   :read,
+                  type: :string
+
+        attribute :text,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/model/operator/cancellation_reason_with_translations_spec.rb
+++ b/spec/ioki/model/operator/cancellation_reason_with_translations_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::CancellationReasonWithTranslations do
+  it { is_expected.to define_attribute(:slug).as(:string) }
+  it { is_expected.to define_attribute(:translations).as(:object).with(class_name: 'MultilanguageString') }
+end

--- a/spec/ioki/model/operator/multilanguage_string_spec.rb
+++ b/spec/ioki/model/operator/multilanguage_string_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::MultilanguageString do
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:translations).as(:array).with(class_name: 'Translation') }
+end

--- a/spec/ioki/model/operator/product_spec.rb
+++ b/spec/ioki/model/operator/product_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Ioki::Model::Operator::Product do
   it { is_expected.to define_attribute(:service_time_info).as(:string) }
   it { is_expected.to define_attribute(:state).as(:string) }
   it { is_expected.to define_attribute(:timezone).as(:object).with(class_name: 'Timezone') }
+
+  it {
+    is_expected.to define_attribute(:translated_ride_cancellation_reasons).as(:array)
+      .with(class_name: 'CancellationReasonWithTranslations')
+  }
+
   it { is_expected.to define_attribute(:walker_boarding_time).as(:integer) }
   it { is_expected.to define_attribute(:wheelchair_boarding_time).as(:integer) }
 end

--- a/spec/ioki/model/operator/translation_spec.rb
+++ b/spec/ioki/model/operator/translation_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Translation do
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:language).as(:string) }
+  it { is_expected.to define_attribute(:text).as(:string) }
+end


### PR DESCRIPTION
This PR will add the `translated_ride_cancellation_reasons` attribute to the Product model for the operator api.