### PR TITLE
Operator Api | Add phone calls

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -244,6 +244,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'products', :id, 'rides', :id],
         path:        'notifications',
         model_class: Ioki::Model::Operator::Notification
+      ),
+      Endpoints::Index.new(
+        :rides_phone_calls,
+        base_path:   [API_BASE_PATH, 'products', :id, 'rides', :id],
+        path:        'phone_calls',
+        model_class: Ioki::Model::Operator::PhoneCall
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/phone_call.rb
+++ b/lib/ioki/model/operator/phone_call.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class PhoneCall < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :call_to_caller_sid,
+                  on:   :read,
+                  type: :string
+
+        attribute :call_to_caller_status,
+                  on:   :read,
+                  type: :string
+
+        attribute :call_to_caller_completed_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :call_to_callee_sid,
+                  on:   :read,
+                  type: :string
+
+        attribute :call_to_callee_status,
+                  on:   :read,
+                  type: :string
+
+        attribute :call_to_callee_completed_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :from_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :to_id,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/model/operator/phone_call_spec.rb
+++ b/spec/ioki/model/operator/phone_call_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::PhoneCall do
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+  it { is_expected.to define_attribute(:call_to_caller_sid).as(:string) }
+  it { is_expected.to define_attribute(:call_to_caller_status).as(:string) }
+  it { is_expected.to define_attribute(:call_to_caller_completed_at).as(:date_time) }
+  it { is_expected.to define_attribute(:call_to_callee_sid).as(:string) }
+  it { is_expected.to define_attribute(:call_to_callee_status).as(:string) }
+  it { is_expected.to define_attribute(:call_to_callee_completed_at).as(:date_time) }
+  it { is_expected.to define_attribute(:from_id).as(:string) }
+  it { is_expected.to define_attribute(:to_id).as(:string) }
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1289,4 +1289,16 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::Notification))
     end
   end
+
+  describe '#rides_phone_calls(product_id, ride_id, ...)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/rides/01/phone_calls')
+        result_with_index_data
+      end
+
+      expect(operator_client.rides_phone_calls('0815', '01', options))
+        .to all(be_a(Ioki::Model::Operator::PhoneCall))
+    end
+  end
 end


### PR DESCRIPTION
This PR will add the endpoint `rides_phone_calls` which makes it possible to retrieve all phone calls for a specific ride.