### PR TITLE
Operator API | Add write actions for operators

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -195,8 +195,13 @@ module Ioki
       Endpoints.crud_endpoints(
         :operator,
         base_path:   [API_BASE_PATH, 'providers', :id],
-        model_class: Ioki::Model::Operator::Operator,
-        except:      [:create, :update, :delete]
+        model_class: Ioki::Model::Operator::Operator
+      ),
+      Endpoints.custom_endpoints(
+        :operator,
+        actions:     { 'set_default' => :patch },
+        path:        [API_BASE_PATH, 'providers', :id, 'operators', :id],
+        model_class: Ioki::Model::Operator::Operator
       ),
       Endpoints.crud_endpoints(
         :area,

--- a/lib/ioki/model/operator/operator.rb
+++ b/lib/ioki/model/operator/operator.rb
@@ -40,6 +40,11 @@ module Ioki
         attribute :slug,
                   on:   [:create, :read, :update],
                   type: :string
+
+        attribute :locale,
+                  on:             [:create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
       end
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1109,6 +1109,62 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#create_operator(provider_id)' do
+    let(:operator) { Ioki::Model::Operator::Operator.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/operators')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.operator('0815', operator, options))
+        .to be_a(Ioki::Model::Operator::Operator)
+    end
+  end
+
+  describe '#update_operator(product_id, operator)' do
+    let(:operator) { Ioki::Model::Operator::Operator.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/operators/4711')
+        expect(params[:method]).to eq :patch
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_operator('0815', operator, options))
+        .to be_a(Ioki::Model::Operator::Operator)
+    end
+  end
+
+  describe '#delete_operator(product_id, operator_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/operators/4711')
+        result_with_data
+      end
+
+      expect(operator_client.delete_operator('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::Operator)
+    end
+  end
+
+  describe '#set_default_operator(product_id, operator)' do
+    let(:operator) { Ioki::Model::Operator::Operator.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/operators/4711/set_default')
+        expect(params[:method]).to eq :patch
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.operator_set_default('0815', operator, options))
+        .to be_a(Ioki::Model::Operator::Operator)
+    end
+  end
+
   describe '#area(product_id, area_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
Adds the following endpoints to the operator API:

- `create_operator`
- `update_operator`
- `delete_operator`
- `operator_set_default`