### PR TITLE
Operator Api | Change access for matching_rank

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -66,7 +66,7 @@ module Ioki
                   type:           :string
 
         attribute :matching_rank,
-                  on:   :read,
+                  on:   [:create, :read, :update],
                   type: :integer
 
         attribute :paused,

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:end_location_type).as(:string) }
     it { is_expected.to define_attribute(:ends_at).as(:date_time) }
     it { is_expected.to define_attribute(:matching_configuration_id).as(:string) }
+    it { is_expected.to define_attribute(:matching_rank).as(:integer) }
     it { is_expected.to define_attribute(:paused).as(:boolean) }
     it { is_expected.to define_attribute(:pauses).as(:array).with(class_name: 'Pause') }
     it { is_expected.to define_attribute(:planned_ends_at).as(:date_time) }


### PR DESCRIPTION
This PR will change the access rights for the attribute `matching_rank` of the `TaskList` model.