### PR TITLE
Operator Api | Fix Line and Linestop model

### DIFF
--- a/lib/ioki/model/operator/line.rb
+++ b/lib/ioki/model/operator/line.rb
@@ -21,9 +21,8 @@ module Ioki
                   type: :date_time
 
         attribute :name,
-                  on:             [:read, :create, :update],
-                  omit_if_nil_on: [:create, :update],
-                  type:           :string
+                  on:   [:read, :create, :update],
+                  type: :string
 
         attribute :mode,
                   on:             [:read, :create, :update],

--- a/lib/ioki/model/operator/line.rb
+++ b/lib/ioki/model/operator/line.rb
@@ -4,17 +4,54 @@ module Ioki
   module Model
     module Operator
       class Line < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :name, on: [:read, :create, :update], type: :string
-        attribute :mode, on: [:read, :create, :update], type: :string
-        attribute :route_number, on: [:read, :create, :update], type: :string
-        attribute :skip_time_window_check, on: [:read, :create, :update], type: :boolean
-        attribute :slug, on: [:read, :create, :update], type: :string
-        attribute :variant, on: [:read, :create, :update], type: :string
-        attribute :line_stops, type: :array, on: :read, class_name: 'LineStop'
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :name,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :mode,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :route_number,
+                  on:   [:read, :create, :update],
+                  type: :string
+
+        attribute :skip_time_window_check,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
+
+        attribute :slug,
+                  on:             [:read, :create, :update],
+                  type:           :string,
+                  omit_if_nil_on: [:create, :update]
+
+        attribute :variant,
+                  on:   [:read, :create, :update],
+                  type: :string
+
+        attribute :line_stops,
+                  type:       :array,
+                  on:         :read,
+                  class_name: 'LineStop'
       end
     end
   end

--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -22,12 +22,12 @@ module Ioki
 
         attribute :tier,
                   on:             [:read, :create, :update],
-                  omit_if_nil_on: [:create, :update],
+                  omit_if_nil_on: [:update],
                   type:           :integer
 
         attribute :relative_time,
                   on:             [:read, :create, :update],
-                  omit_if_nil_on: [:create, :update],
+                  omit_if_nil_on: [:update],
                   type:           :integer
 
         attribute :dropoff_mode,
@@ -56,9 +56,8 @@ module Ioki
                   type:           :boolean
 
         attribute :station_id,
-                  on:             [:read, :create],
-                  omit_if_nil_on: [:create],
-                  type:           :string
+                  on:   [:read, :create],
+                  type: :string
 
         attribute :version,
                   on:   :read,

--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -4,19 +4,65 @@ module Ioki
   module Model
     module Operator
       class LineStop < Base
-        attribute :type, on: :read, type: :string
-        attribute :id, on: :read, type: :string
-        attribute :created_at, on: :read, type: :date_time
-        attribute :updated_at, on: :read, type: :date_time
-        attribute :tier, on: [:read, :create, :update], type: :integer
-        attribute :relative_time, on: [:read, :create, :update], type: :integer
-        attribute :dropoff_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
-        attribute :pickup_mode, on: [:read, :create, :update], type: :string, omit_if_nil_on: [:create, :update]
-        attribute :supports_pickup, on: [:read, :create, :update], type: :boolean
-        attribute :supports_dropoff, on: [:read, :create, :update], type: :boolean
-        attribute :supports_pass_through, on: [:read, :create, :update], type: :boolean
-        attribute :station_id, on: [:read, :create], type: :string
-        attribute :version, on: :read, type: :integer
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :tier,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
+
+        attribute :relative_time,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
+
+        attribute :dropoff_mode,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :pickup_mode,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :supports_pickup,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
+
+        attribute :supports_dropoff,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
+
+        attribute :supports_pass_through,
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
+
+        attribute :station_id,
+                  on:             [:read, :create],
+                  omit_if_nil_on: [:create],
+                  type:           :string
+
+        attribute :version,
+                  on:   :read,
+                  type: :integer
       end
     end
   end

--- a/spec/ioki/model/operator/line_spec.rb
+++ b/spec/ioki/model/operator/line_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Line do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:mode).as(:string) }
+  it { is_expected.to define_attribute(:route_number).as(:string) }
+  it { is_expected.to define_attribute(:skip_time_window_check).as(:boolean) }
+  it { is_expected.to define_attribute(:slug).as(:string) }
+  it { is_expected.to define_attribute(:variant).as(:string) }
+  it { is_expected.to define_attribute(:line_stops).as(:array).with(class_name: 'LineStop') }
+end

--- a/spec/ioki/model/operator/line_stop_spec.rb
+++ b/spec/ioki/model/operator/line_stop_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::LineStop do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time) }
+  it { is_expected.to define_attribute(:tier).as(:integer) }
+  it { is_expected.to define_attribute(:relative_time).as(:integer) }
+  it { is_expected.to define_attribute(:dropoff_mode).as(:string) }
+  it { is_expected.to define_attribute(:pickup_mode).as(:string) }
+  it { is_expected.to define_attribute(:supports_pickup).as(:boolean) }
+  it { is_expected.to define_attribute(:supports_dropoff).as(:boolean) }
+  it { is_expected.to define_attribute(:supports_pass_through).as(:boolean) }
+  it { is_expected.to define_attribute(:station_id).as(:string) }
+  it { is_expected.to define_attribute(:version).as(:integer) }
+end


### PR DESCRIPTION
This PR will fix access for some attributes of the Line and LineStop model.

__Line__
For these attributes `nil` should be omitted on create and update.
- name 
- mode
- skip_time_window_check
- slug

same for
__LineStop__
- tier
- relative_time
- supports_pickup
- supports_dropoff
- supports_pass_through
- station_id

Hope this won't break stuff for you @phylor 