### PR TITLE
fix: TaskList model

### DIFF
--- a/lib/ioki/model/operator/operator.rb
+++ b/lib/ioki/model/operator/operator.rb
@@ -29,8 +29,9 @@ module Ioki
                   type: :boolean
 
         attribute :matching_rank,
-                  on:   :read,
-                  type: :integer
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
 
         attribute :name,
                   on:   [:create, :read, :update],

--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -66,8 +66,9 @@ module Ioki
                   type:           :string
 
         attribute :matching_rank,
-                  on:   [:create, :read, :update],
-                  type: :integer
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
 
         attribute :paused,
                   on:   :read,

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -70,8 +70,9 @@ module Ioki
                   type:           :string
 
         attribute :matching_rank,
-                  on:   :read,
-                  type: :integer
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
 
         attribute :model,
                   on:             [:create, :read, :update],


### PR DESCRIPTION
This PR will add the `omit_if_nil_on` part to the `matching_rank` attribute of the TaskList model and change access for `matching_rank` for Vehicle and Operator.