### PR TITLE
Platform API | Add more attributes to provider and platform

### DIFF
--- a/lib/ioki/model/platform/cancellation_statement.rb
+++ b/lib/ioki/model/platform/cancellation_statement.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class CancellationStatement < Base
+        attribute :group, on: :read, type: :string
+        attribute :identifier, on: :read, type: :string
+        attribute :product_id, on: :read, type: :string
+        attribute :title, on: :read, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/product.rb
+++ b/lib/ioki/model/platform/product.rb
@@ -8,29 +8,44 @@ module Ioki
         attribute :id, on: :read, type: :string
         attribute :created_at, on: :read, type: :date_time
         attribute :updated_at, on: :read, type: :date_time
+        attribute :version, on: :read, type: :integer
         attribute :ad_hoc_bookable, on: :read, type: :boolean
-        attribute :announcement, on: :read, type: :object, class_name: 'Announcement'
-        attribute :area, type: :object, on: :read, class_name: 'Area'
-        attribute :bounding_box, on: :read, type: :object, class_name: 'BoundingBox'
+        attribute :comment, on: :read, type: :string
         attribute :description, on: :read, type: :string
-        attribute :fixed_stations, on: :read, type: :array, class_name: 'Station'
-        attribute :matching_configurations, on: :read, type: :array, class_name: 'MatchingConfiguration'
-        attribute :name, on: :read
-        attribute :prebookable, on: :read, type: :boolean
-        attribute :provider, type: :object, on: :read, class_name: 'Provider'
-        attribute :ride_options, on: :read, type: :object, class_name: 'RideOptions'
-        attribute :passenger_options, on: :read, type: :array, class_name: 'PassengerOption'
-        attribute :passenger_types, on: :read, type: :array, class_name: 'PassengerType'
+        attribute :driver_emergency_phone_number, on: :read, type: :string
+        attribute :drivers_planning_url, on: :read, type: :string
+        attribute :display_stations_on_map, on: :read, type: :boolean
+        attribute :supports_passenger_cancellation_statement, on: :read, type: :boolean
+        attribute :help_url, on: :read, type: :string
+        attribute :name, on: :read, type: :string
         attribute :payment_method_allowed_on_booking, on: :read, type: :boolean
         attribute :payment_method_required_on_booking, on: :read, type: :boolean
-        attribute :product_ride_options, on: :read, type: :array, class_name: 'RideOption'
+        attribute :prebookable, on: :read, type: :boolean
+        attribute :ride_options, on: :read, type: :object, class_name: 'RideOptions'
         attribute :ride_rating_criteria, on: :read, type: :array
         attribute :service_time_info, on: :read, type: :string
+        attribute :support_email, on: :read, type: :string
+        attribute :support_phone_number, on: :read, type: :string
+        attribute :support_website_url, on: :read, type: :string
+        attribute :tableau_url, on: :read, type: :string
+        attribute :task_lists_planning_url, on: :read, type: :string
         attribute :timezone, on: :read, type: :object, class_name: 'Timezone'
-        attribute :tipping, on: :read, type: :object, class_name: 'Tipping'
+        attribute :vehicle_operator_info, on: :read, type: :string
+        attribute :vehicles_planning_url, on: :read, type: :string
+        attribute :announcement, on: :read, type: :object, class_name: 'Announcement'
+        attribute :announcements, on: :read, type: :array, class_name: 'Announcement'
+        attribute :area, type: :object, on: :read, class_name: 'Area'
+        attribute :bounding_box, on: :read, type: :object, class_name: 'BoundingBox'
         attribute :features, on: :read, type: :object, class_name: 'ProductFeatures'
-        attribute :display_stations_on_map, on: :read, type: :boolean
-        attribute :version, on: :read, type: :integer
+        attribute :driver_cancellation_statements, on: :read, type: :array, class_name: 'CancellationStatement'
+        attribute :passenger_cancellation_statements, on: :read, type: :array, class_name: 'CancellationStatement'
+        attribute :fixed_stations, on: :read, type: :array, class_name: 'Station'
+        attribute :matching_configurations, on: :read, type: :array, class_name: 'MatchingConfiguration'
+        attribute :passenger_options, on: :read, type: :array, class_name: 'PassengerOption'
+        attribute :passenger_types, on: :read, type: :array, class_name: 'PassengerType'
+        attribute :product_ride_options, on: :read, type: :array, class_name: 'RideOption'
+        attribute :provider, type: :object, on: :read, class_name: 'Provider'
+        attribute :tipping, on: :read, type: :object, class_name: 'Tipping'
       end
     end
   end

--- a/lib/ioki/model/platform/provider.rb
+++ b/lib/ioki/model/platform/provider.rb
@@ -20,6 +20,10 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
+        attribute :version,
+                  on:   :read,
+                  type: :integer
+
         attribute :city,
                   on:   :read,
                   type: :string
@@ -36,15 +40,17 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
-        attribute :default_operator,
-                  on:         :read,
-                  type:       :object,
-                  class_name: 'Operator'
+        attribute :help_url,
+                  on:   :read,
+                  type: :string
 
-        attribute :features,
-                  on:         :read,
-                  type:       :object,
-                  class_name: 'ProviderFeatures'
+        attribute :imprint_url,
+                  on:   :read,
+                  type: :string
+
+        attribute :imprint,
+                  on:   :read,
+                  type: :string
 
         attribute :logpay_payment_method_types,
                   on:   :read,
@@ -58,11 +64,19 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :other_url,
+                  on:   :read,
+                  type: :string
+
         attribute :personal_discount_payment_method_types,
                   on:   :read,
                   type: :array
 
         attribute :postal_code,
+                  on:   :read,
+                  type: :string
+
+        attribute :privacy_policy_url,
                   on:   :read,
                   type: :string
 
@@ -73,11 +87,6 @@ module Ioki
         attribute :ride_payment_method_types,
                   on:   :read,
                   type: :array
-
-        attribute :service_credit_options,
-                  on:         :read,
-                  type:       :object,
-                  class_name: 'ServiceCreditOptions'
 
         attribute :service_credit_payment_method_types,
                   on:   :read,
@@ -103,13 +112,49 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :support_email,
+                  on:   :read,
+                  type: :string
+
+        attribute :support_phone_number,
+                  on:   :read,
+                  type: :string
+
+        attribute :support_website_url,
+                  on:   :read,
+                  type: :string
+
+        attribute :terms_of_service_url,
+                  on:   :read,
+                  type: :string
+
         attribute :tip_payment_method_types,
                   on:   :read,
                   type: :array
 
-        attribute :version,
+        attribute :ticketing_payment_method_types,
                   on:   :read,
-                  type: :integer
+                  type: :array
+
+        attribute :default_operator,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Operator'
+
+        attribute :features,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'ProviderFeatures'
+
+        attribute :operators,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Operator'
+
+        attribute :service_credit_options,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'ServiceCreditOptions'
       end
     end
   end


### PR DESCRIPTION
This adds more attributes to `Provider` and `Product` in the platform API. I also sorted them according to the documentation for easier updates.