### PR TITLE
Platform API | Add `minimum_age_confirmation` and `analytics_tracking` to `Provider#features`

### DIFF
--- a/lib/ioki/model/platform/minimum_age_confirmation.rb
+++ b/lib/ioki/model/platform/minimum_age_confirmation.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class MinimumAgeConfirmation < Base
+        unvalidated true # No specification available.
+
+        attribute :minimum_age, on: :read, type: :integer
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/provider_features.rb
+++ b/lib/ioki/model/platform/provider_features.rb
@@ -8,6 +8,7 @@ module Ioki
 
         attribute :analytics_tracking, type: :boolean, on: :read
         attribute :failed_payment_handling, type: :boolean, on: :read
+        attribute :minimum_age_confirmation, type: :object, on: :read, class_name: 'MinimumAgeConfirmation'
         attribute :payment, type: :boolean, on: :read
         attribute :promo_codes, type: :boolean, on: :read
       end

--- a/lib/ioki/model/platform/provider_features.rb
+++ b/lib/ioki/model/platform/provider_features.rb
@@ -6,6 +6,7 @@ module Ioki
       class ProviderFeatures < Base
         unvalidated true # Specification not available
 
+        attribute :analytics_tracking, type: :boolean, on: :read
         attribute :failed_payment_handling, type: :boolean, on: :read
         attribute :payment, type: :boolean, on: :read
         attribute :promo_codes, type: :boolean, on: :read


### PR DESCRIPTION
This adds two more provider features to the platform API.