### PR TITLE
Passenger API | Add update of user flags

### DIFF
--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -79,6 +79,13 @@ module Ioki
         outgoing_model_class: Ioki::Model::Passenger::UserPhoneNumber
       ),
       Endpoints::Create.new(
+        :user_flags,
+        base_path:            [API_BASE_PATH, 'user'],
+        path:                 'flags',
+        model_class:          Ioki::Model::Passenger::User,
+        outgoing_model_class: Ioki::Model::Passenger::UserFlags
+      ),
+      Endpoints::Create.new(
         :phone_verification_request,
         base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Passenger::PhoneVerificationRequest

--- a/lib/ioki/model/passenger/user_flags.rb
+++ b/lib/ioki/model/passenger/user_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class UserFlags < Base
+        attribute :version, on: :create, type: :integer
+        attribute :terms_accepted, on: :create, type: :boolean, omit_if_nil_on: :create
+        attribute :minimum_age_confirmed, on: :create, type: :boolean, omit_if_nil_on: :create
+        attribute :analytics_tracking, on: :create, type: :boolean, omit_if_nil_on: :create
+      end
+    end
+  end
+end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -208,6 +208,20 @@ RSpec.describe Ioki::PassengerApi do
     end
   end
 
+  describe '#create_user_flags' do
+    let(:user_flags) { Ioki::Model::Passenger::UserFlags.new(minimum_age_confirmed: true) }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/user/flags')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_user_flags(user_flags, options.merge(model: user_flags)))
+        .to be_a Ioki::Model::Passenger::User
+    end
+  end
+
   describe '#show_user' do
     it 'calls request on the client with expected params' do
       expect(passenger_client).to receive(:request) do |params|


### PR DESCRIPTION
This adds the endpoint to update user flags via the passenger API.