### PR TITLE
Operator API | Add `Station#visible_on_map_in_passenger_client`

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -128,8 +128,9 @@ module Ioki
                   type:           :integer
 
         attribute :visible_on_map_in_passenger_client,
-                  on:   :read,
-                  type: :boolean
+                  on:             [:read, :create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :boolean
 
         attribute :walker_boarding_time,
                   on:   [:read, :create, :update],


### PR DESCRIPTION
This additionally adds `Station#visible_on_map_in_passenger_client` to `create` and `update` in the operator API.