### PR TITLE
Operator Api | Allow `nil` for `matching_rank`

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -66,9 +66,8 @@ module Ioki
                   type:           :string
 
         attribute :matching_rank,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
-                  type:           :integer
+                  on:   [:create, :read, :update],
+                  type: :integer
 
         attribute :paused,
                   on:   :read,

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -75,9 +75,8 @@ module Ioki
                   type:           :string
 
         attribute :matching_rank,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
-                  type:           :integer
+                  on:   [:create, :read, :update],
+                  type: :integer
 
         attribute :model,
                   on:             [:create, :read, :update],


### PR DESCRIPTION
With this PR `nil` will be a valid value for the attribute `matching_rank` of the models `TaskList` and `Vehicle`.

@phylor hope this is fine!