### PR TITLE
Operator Api: Allow `nil` on update for `line_id`

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -131,7 +131,7 @@ module Ioki
 
         attribute :line_id,
                   on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
+                  omit_if_nil_on: [:create],
                   type:           :string
 
         attribute :version,


### PR DESCRIPTION
As the title suggests, `nil` is a valid value for `line_id` on `TaskList#update`. This PR will change that.

@phylor let me know if there are any issues, thanks.