### PR TITLE
Operator Api | Add `dropoff_task` and `pickup_task` to Ride

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -73,6 +73,11 @@ module Ioki
                   type:       :object,
                   class_name: 'CalculatedPoint'
 
+        attribute :dropoff_task,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Task'
+
         attribute :estimated_direct_distance,
                   on:   :read,
                   type: :integer
@@ -107,6 +112,11 @@ module Ioki
                   on:         :read,
                   type:       :object,
                   class_name: 'CalculatedPoint'
+
+        attribute :pickup_task,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Task'
 
         attribute :prebooked,
                   on:   :read,

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:driver_id).as(:string) }
   it { is_expected.to define_attribute(:driver_can_be_called).as(:boolean) }
   it { is_expected.to define_attribute(:dropoff).as(:object).with(class_name: 'CalculatedPoint') }
+  it { is_expected.to define_attribute(:dropoff_task).as(:object).with(class_name: 'Task') }
   it { is_expected.to define_attribute(:estimated_direct_distance).as(:integer) }
   it { is_expected.to define_attribute(:estimated_direct_duration).as(:integer) }
   it { is_expected.to define_attribute(:needs_cancellation_code).as(:boolean) }
@@ -25,6 +26,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:passengers).as(:array).with(class_name: 'RidePassenger') }
   it { is_expected.to define_attribute(:payment_state).as(:string) }
   it { is_expected.to define_attribute(:pickup).as(:object).with(class_name: 'CalculatedPoint') }
+  it { is_expected.to define_attribute(:pickup_task).as(:object).with(class_name: 'Task') }
   it { is_expected.to define_attribute(:prebooked).as(:boolean) }
   it { is_expected.to define_attribute(:product_id).as(:string) }
   it { is_expected.to define_attribute(:public_transport_uri).as(:string) }


### PR DESCRIPTION
This PR will add `dropoff_task` and `pickup_task` to the Ride model.