### PR TITLE
[Breaking] Change to serialize only dirty attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ioki-ruby (0.14.0)
+      activemodel (>= 6.0.0)
       faraday (>= 1.8, < 3.0)
       faraday_middleware (~> 1.2)
       oauth2 (>= 2.0.2, < 3)
@@ -10,12 +11,27 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     awesome_print (1.9.2)
+    base64 (0.2.0)
     bigdecimal (3.1.6)
     coderay (1.1.3)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -25,6 +41,8 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.0)
+    drb (2.2.0)
+      ruby2_keywords
     faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -68,12 +86,15 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.1.0)
     hashie (5.0.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     io-console (0.7.1)
     irb (1.11.0)
       rdoc
       reline (>= 0.3.8)
     json (2.7.1)
-    jwt (2.7.1)
+    jwt (2.8.0)
+      base64
     language_server-protocol (3.17.0.3)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -86,8 +107,10 @@ GEM
       net-smtp
     method_source (1.0.0)
     mini_mime (1.1.5)
+    minitest (5.22.2)
     multi_xml (0.6.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
+    mutex_m (0.2.0)
     nenv (0.3.0)
     net-imap (0.4.2)
       date
@@ -120,7 +143,7 @@ GEM
       stringio
     public_suffix (5.0.4)
     racc (1.7.3)
-    rack (3.0.8)
+    rack (3.0.9.1)
     rainbow (3.1.1)
     rake (13.1.0)
     rb-fsevent (0.11.2)
@@ -181,6 +204,8 @@ GEM
     stringio (3.1.0)
     thor (1.2.1)
     timeout (0.4.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     vcr (6.2.0)
     version_gem (1.1.3)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,53 @@ the values in `Ioki.config`. Ioki.config will respect the values set up by
 `Ioki.configure`. If not set, it will take the ENV value and finally fall back
 for most configurable attributes to a baked in default.
 
+## Serialization
+
+ioki-ruby's main task is to serialize models to JSON and send the serialized representation to the API. All attributes changes are tracked and only changed attributes are serialized and sent to the API.
+
+Make sure that all required attributes are properly set on the model, as ioki-ruby currently does not validate the serialized data before sending it to the API.
+
+Please note that in certain cases sending an attribute with the value `nil` results in a different behavior than not sending the attribute at all. You therefore have to ensure to only set the attributes which are meant to be sent to the API.
+
+Example:
+
+```ruby
+irb(main):002> line = Ioki::Model::Operator::Line.new(slug: 'my-line')
+=> Ioki::Model::Operator::Line:3400 @attributes={:slug=>"my-line"}
+irb(main):003> line.serialize
+=> {:slug=>"my-line"}
+
+irb(main):004> line.changed_attributes
+=> {:slug=>"my-line"}
+irb(main):005> line.attributes
+=>
+{:type=>nil,
+ :id=>nil,
+ :created_at=>nil,
+ :updated_at=>nil,
+ :name=>nil,
+ :mode=>nil,
+ :route_number=>nil,
+ :skip_time_window_check=>nil,
+ :slug=>"my-line",
+ :variant=>nil,
+ :line_stops=>nil}
+
+# Set attributes to `nil` if you want to explicitly send `nil` to the API.
+irb(main):007> line.slug = nil
+=> nil
+irb(main):008> line.serialize
+=> {:slug=>nil}
+
+# If you do not want to send an attribute to the API, but already have set it
+# before, use `clear_myattribute_change`. Replace `myattribute` with the name
+# of the attribute.
+irb(main):009> line.clear_slug_change
+=> nil
+irb(main):010> line.serialize
+=> {}
+```
+
 ## Webhooks
 
 Webhooks are a way to receive updates about changes when they happen on the

--- a/ioki-ruby.gemspec
+++ b/ioki-ruby.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activemodel', '>= 6.0.0'
   spec.add_dependency 'faraday', '>= 1.8', '< 3.0'
   spec.add_dependency 'faraday_middleware', '~> 1.2'
   spec.add_dependency 'oauth2', '>= 2.0.2', '< 3'

--- a/lib/ioki.rb
+++ b/lib/ioki.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_model'
+
 require 'ioki/support'
 require 'ioki/configuration'
 require 'ioki/model'

--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -42,7 +42,9 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
+        model_class
+          .new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
+          .tap(&:clear_changes_information)
       end
     end
   end

--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -33,7 +33,9 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'], nil, show_deprecation_warnings: false)
+        model_class
+          .new(parsed_response['data'], nil, show_deprecation_warnings: false)
+          .tap(&:clear_changes_information)
       end
     end
   end

--- a/lib/ioki/apis/endpoints/index.rb
+++ b/lib/ioki/apis/endpoints/index.rb
@@ -75,7 +75,11 @@ module Ioki
         )
 
         [
-          parsed_response['data'].map { |attr| model_class.new(attr, nil, show_deprecation_warnings: false) },
+          parsed_response['data'].map do |attr|
+            model_class
+              .new(attr, nil, show_deprecation_warnings: false)
+              .tap(&:clear_changes_information)
+          end,
           parsed_response,
           response
         ]

--- a/lib/ioki/apis/endpoints/show.rb
+++ b/lib/ioki/apis/endpoints/show.rb
@@ -29,7 +29,9 @@ module Ioki
         model = options[:model] if options[:model].is_a?(model_class)
         attributes, etag = model_params(client, args, options, model)
 
-        model_class.new(attributes, etag, show_deprecation_warnings: false)
+        model_class
+          .new(attributes, etag, show_deprecation_warnings: false)
+          .tap(&:clear_changes_information)
       end
 
       private

--- a/lib/ioki/apis/endpoints/update.rb
+++ b/lib/ioki/apis/endpoints/update.rb
@@ -41,7 +41,9 @@ module Ioki
 
         return if parsed_response.nil?
 
-        model_class.new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
+        model_class
+          .new(parsed_response['data'], response.headers[:etag], show_deprecation_warnings: false)
+          .tap(&:clear_changes_information)
       end
     end
   end

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -32,7 +32,7 @@ module Ioki
             @_attributes[attribute]
           end
 
-          define_method :"#{attribute}=" do |value, show_deprecation_warnings: true, force_change: false|
+          define_method :"#{attribute}=" do |value, show_deprecation_warnings: true|
             if show_deprecation_warnings && attribute_deprecated?(attribute)
               deprecation_warning deprecated_attribute_message(attribute)
             end
@@ -40,7 +40,7 @@ module Ioki
             new_value = type_cast_attribute_value(attribute, value)
             @_raw_attributes[attribute] = value
 
-            if force_change || @_attributes[attribute] != new_value
+            if @_attributes[attribute] != new_value || !changed_attributes.include?(attribute)
               send("#{attribute}_will_change!")
               @_attributes[attribute] = new_value
             end
@@ -240,7 +240,7 @@ module Ioki
           provided_attribute = @_raw_attributes.key?(attribute)
           value = provided_attribute ? @_raw_attributes[attribute] : definition[:default]
 
-          public_send("#{attribute}=", value, show_deprecation_warnings: false, force_change: provided_attribute)
+          public_send("#{attribute}=", value, show_deprecation_warnings: false) if provided_attribute || !value.nil?
         end
       end
 

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -186,7 +186,7 @@ module Ioki
 
       # may get overridden in hard ways by subclasses. This default
       # implementation should bring us a long way.
-      def serialize(usecase = :read)
+      def serialize(usecase = :read, only_changed: true)
         if !@_raw_attributes.is_a?(Hash)
           return @_raw_attributes.map { |object| object.serialize(usecase) } if @_raw_attributes.is_a?(Array)
 
@@ -200,7 +200,7 @@ module Ioki
 
           next if Ioki.config.ignore_deprecated_attributes && definition[:deprecated]
 
-          next unless attribute_changed?(attribute)
+          next if only_changed && !attribute_changed?(attribute)
 
           next if definition.key?(:omit_if_nil_on) &&
                   Array(definition[:omit_if_nil_on]).include?(usecase) &&

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -102,7 +102,7 @@ module Ioki
 
         reset_attributes!
 
-        set_base_class if respond_to?(:set_base_class)
+        set_base_class if Kernel.instance_method(:respond_to?).bind(self).call(:set_base_class)
       end
 
       def inspect

--- a/spec/ioki/endpoints/create_spec.rb
+++ b/spec/ioki/endpoints/create_spec.rb
@@ -63,6 +63,28 @@ RSpec.describe Ioki::Endpoints::Create do
         expect(result).to be_nil
       end
     end
+
+    context 'with passed attributes' do
+      let(:model) { Ioki::Model::Platform::Product.new(name: 'My product') }
+
+      it 'provides change information correctly' do
+        expect(model.changes).to eq({ 'name' => [nil, 'My product'] })
+
+        expect(client).to receive(:request).with(
+          url:    url,
+          method: :post,
+          body:   { data: serialized_model },
+          params: params
+        ).and_return(response)
+
+        result = endpoint.call(client, model, [], params: params)
+
+        expect(result).not_to eq model
+        expect(model.name).to eq 'My product'
+        expect(model.changes).to eq({ 'name' => [nil, 'My product'] })
+        expect(result.changes).to be_empty
+      end
+    end
   end
 
   it 'supports an array as a path' do

--- a/spec/ioki/endpoints/delete_spec.rb
+++ b/spec/ioki/endpoints/delete_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Ioki::Endpoints::Delete do
     result = endpoint.call(client, ['0815'], params: params)
 
     expect(result).to be_a(Ioki::Model::Platform::Product)
+    expect(result.changes).to be_empty
     expect(result.id).to eq('0815')
   end
 

--- a/spec/ioki/endpoints/index_spec.rb
+++ b/spec/ioki/endpoints/index_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Ioki::Endpoints::Index do
 
     expect(result).to be_a(Array)
     expect(result.size).to eq(2)
+    expect(result.map(&:changes)).to all be_empty
   end
 
   it 'returns an Array of the correct model_class' do
@@ -94,6 +95,7 @@ RSpec.describe Ioki::Endpoints::Index do
     expect(result).to be_a(Array)
     expect(result.size).to eq(5)
     expect(result.map(&:id)).to eq(%w[001 002 003 004 005])
+    expect(result.map(&:changes)).to all be_empty
   end
 
   it 'paginates and returns the first page' do
@@ -104,6 +106,7 @@ RSpec.describe Ioki::Endpoints::Index do
     expect(result.data).to be_a(Array)
     expect(result.data.size).to eq(2)
     expect(result.data.map(&:id)).to eq(%w[001 002])
+    expect(result.data.map(&:changes)).to all be_empty
 
     expect(result.meta).to be_a(Ioki::Model::Meta)
     expect(result.meta.page).to eq 1
@@ -118,6 +121,7 @@ RSpec.describe Ioki::Endpoints::Index do
     expect(result.data).to be_a(Array)
     expect(result.data.size).to eq(1)
     expect(result.data.map(&:id)).to eq(%w[005])
+    expect(result.data.map(&:changes)).to all be_empty
 
     expect(result.meta).to be_a(Ioki::Model::Meta)
     expect(result.meta.page).to eq 3

--- a/spec/ioki/endpoints/index_spec.rb
+++ b/spec/ioki/endpoints/index_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe Ioki::Endpoints::Index do
   it 'returns an Array of the correct model_class' do
     result = endpoint.call client, [], model_class: model_class, params: params
 
-    expect(result.first).to be_a(model_class)
-    expect(result.last).to be_a(model_class)
+    expect(result).to all be_a(model_class)
   end
 
   it 'returns an Array with the correct attributes' do

--- a/spec/ioki/endpoints/show_spec.rb
+++ b/spec/ioki/endpoints/show_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Ioki::Endpoints::Show do
 
     expect(result).to be_a(model_class)
     expect(result.id).to eq('0815')
+    expect(result.changes).to all be_empty
   end
 
   it "sets the response's etag to the model" do
@@ -49,7 +50,8 @@ RSpec.describe Ioki::Endpoints::Show do
         params:  params
       ).and_return([parsed_data, response])
 
-      endpoint.call(client, ['0815'], { model: model, params: params })
+      result = endpoint.call(client, ['0815'], { model: model, params: params })
+      expect(result.changes).to all be_empty
     end
   end
 
@@ -80,6 +82,7 @@ RSpec.describe Ioki::Endpoints::Show do
       notification_settings = endpoint.call(client, ['0815'])
 
       expect(notification_settings).to be_a Ioki::Model::Passenger::NotificationSettings
+      expect(notification_settings.changes).to all be_empty
       expect(notification_settings._etag).to eq 'ETAG'
       expect(notification_settings._raw_attributes).to eq parsed_data['data']
       expect(notification_settings.data).to eq [
@@ -125,6 +128,7 @@ RSpec.describe Ioki::Endpoints::Show do
       response = endpoint.call(client, ['0815'])
 
       expect(response).to be_a model_class
+      expect(response.changes).to all be_empty
       expect(response._etag).to eq 'ETAG'
       expect(response._raw_attributes).to eq parsed_data['data']
       expect(response.data).to eq 'test string'

--- a/spec/ioki/endpoints/update_spec.rb
+++ b/spec/ioki/endpoints/update_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Ioki::Endpoints::Update do
       result = endpoint.call(client, model, ['0815'], model_class: model_class, params: params)
 
       expect(result).to be_a(Ioki::Model::Platform::Product)
+      expect(result.changes).to be_empty
       expect(result).not_to eq(model)
       expect(result.id).to eq('0815')
       expect(result.name).to eq('attributes altered by server')
@@ -61,6 +62,28 @@ RSpec.describe Ioki::Endpoints::Update do
         result = endpoint.call(client, model, ['0815'], model_class: model_class, params: params)
 
         expect(result).to be_nil
+      end
+    end
+
+    context 'with passed attributes' do
+      let(:model) { Ioki::Model::Platform::Product.new(name: 'My product') }
+
+      it 'provides change information correctly' do
+        expect(model.changes).to eq({ 'name' => [nil, 'My product'] })
+
+        expect(client).to receive(:request).with(
+          url:    url,
+          method: :patch,
+          body:   { data: serialized_model },
+          params: params
+        ).and_return(response)
+
+        result = endpoint.call(client, model, ['0815'], model_class: model_class, params: params)
+
+        expect(result).to be_a(Ioki::Model::Platform::Product)
+        expect(result.changes).to be_empty
+        expect(result).not_to eq(model)
+        expect(model.changes).to eq({ 'name' => [nil, 'My product'] })
       end
     end
   end

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -539,6 +539,21 @@ RSpec.describe Ioki::Model::Base do
           expect(model.serialize).to eq({ foo: '1' })
         end
       end
+
+      context 'with a nested model' do
+        let(:example_class) do
+          Class.new(Ioki::Model::Base) do
+            attribute :foo, on: [:read, :create]
+            attribute :bar, on: [:read, :create], type: :object, class_name: 'Ioki::Model::Platform::Product'
+          end
+        end
+
+        let(:attributes) { { foo: '1', bar: { type: 'product', name: 'My product' } } }
+
+        it 'includes the nested attributes' do
+          expect(model.serialize).to eq({ foo: '1', bar: { name: 'My product', type: 'product' } })
+        end
+      end
     end
   end
 

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -366,6 +366,53 @@ RSpec.describe Ioki::Model::Base do
           }
         )
       end
+
+      context 'without all attributes' do
+        let(:example_class) do
+          Class.new(Ioki::Model::Base) do
+            attribute :foo, on: :read
+            attribute :bar, type: :string, on: :read
+            attribute :baz, type: :integer, on: :read
+            deprecated_attribute :bak, type: :object, on: :read
+          end
+        end
+
+        let(:attributes) do
+          {
+            foo: '1',
+            bar: '2'
+          }
+        end
+
+        it 'only serializes changed attributes by default' do
+          expect(model.serialize).to eq(
+            {
+              foo: '1',
+              bar: '2'
+            }
+          )
+
+          expect(model.serialize(:read, only_changed: false)).to eq(
+            {
+              foo: '1',
+              bar: '2',
+              baz: nil,
+              bak: nil
+            }
+          )
+
+          Ioki.config.ignore_deprecated_attributes = true
+          expect(model.serialize(:read, only_changed: false)).to eq(
+            {
+              foo: '1',
+              bar: '2',
+              baz: nil
+            }
+          )
+        ensure
+          Ioki.config.ignore_deprecated_attributes = false
+        end
+      end
     end
 
     describe ':on parameter' do

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -321,6 +321,20 @@ RSpec.describe Ioki::Model::Base do
     it 'returns only provided and default attributes' do
       expect(model.changed_attributes).to eq({ foo: 'abc', baz: 3 })
     end
+
+    it 'allows to explicitly set a value to `nil`' do
+      model.bar = nil
+      expect(model.changed_attributes).to eq({ foo: 'abc', bar: nil, baz: 3 })
+    end
+
+    context 'with `nil` for an initialized attribute' do
+      let(:attributes) { { foo: 'abc', bar: nil } }
+
+      it 'includes `nil` in the changed attributes' do
+        expect(model.changed_attributes).to eq({ foo: 'abc', bar: nil, baz: 3 })
+        expect(model.serialize).to eq({ foo: 'abc', bar: nil, baz: 3 })
+      end
+    end
   end
 
   describe 'serialization' do

--- a/spec/ioki/model/base_type_array_spec.rb
+++ b/spec/ioki/model/base_type_array_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Ioki::Model::Base do
     create_ride_request = stub_request(:post, 'https://app.io.ki/api/passenger/rides')
       .with(body: {
               data: {
-                origin:                         {},
-                destination:                    {},
-                passengers:                     [{
+                origin:      {},
+                destination: {},
+                passengers:  [{
                   type:    'adult',
                   options: [
                     {
@@ -29,30 +29,7 @@ RSpec.describe Ioki::Model::Base do
                     }
                   ]
                 }],
-                book_for_others:                nil,
-                cancellable:                    nil,
-                cancellation_reason:            nil,
-                cancellation_reason_translated: nil,
-                driver_can_be_called:           nil,
-                needs_cancellation_code:        nil,
-                passenger_can_be_called:        nil,
-                payment_state:                  nil,
-                prebooked:                      nil,
-                product_id:                     'prd_1',
-                public_transport_uri:           nil,
-                rateable:                       nil,
-                receipts:                       nil,
-                route:                          nil,
-                state:                          nil,
-                support_uri:                    nil,
-                tip:                            nil,
-                tippable:                       nil,
-                valid_for_driver_until:         nil,
-                valid_for_passenger_until:      nil,
-                vehicle:                        nil,
-                vehicle_reached_dropoff:        nil,
-                vehicle_reached_pickup:         nil,
-                options:                        nil
+                product_id:  'prd_1'
               }
             })
       .to_return_json(

--- a/spec/ioki/model/platform/user_email_spec.rb
+++ b/spec/ioki/model/platform/user_email_spec.rb
@@ -36,17 +36,33 @@ RSpec.describe Ioki::Model::Platform::UserEmail do
       )
     end
 
-    it 'serializes omitted attributes when the action does not match' do
-      serialized = described_class.new.serialize(:read)
+    context 'when the action does not match' do
+      context 'when attributes are explicitly specified' do
+        let(:attributes) do
+          {
+            confirmed:     nil,
+            email_address: nil,
+            newsletter:    nil,
+            receipt:       nil
+          }
+        end
 
-      expect(serialized).to eq(
-        {
-          confirmed:     nil,
-          email_address: nil,
-          newsletter:    nil,
-          receipt:       nil
-        }
-      )
+        it 'serializes omitted attributes' do
+          serialized = described_class.new(attributes).serialize(:read)
+
+          expect(serialized).to eq(
+            attributes
+          )
+        end
+      end
+
+      context 'when attributes are not explicitly specified' do
+        it 'does not serialize anything' do
+          serialized = described_class.new.serialize(:read)
+
+          expect(serialized).to eq({})
+        end
+      end
     end
   end
 end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -126,7 +126,9 @@ RSpec.describe Ioki::PassengerApi do
     let(:cancellation) do
       Ioki::Model::Passenger::Cancellation.new(
         ride_id:                   'RIDE_ID',
-        cancellation_statement_id: 'CANCELLATION_STATEMENT_ID'
+        cancellation_statement_id: 'CANCELLATION_STATEMENT_ID',
+        ride_version:              nil,
+        code:                      nil
       )
     end
 


### PR DESCRIPTION
Closes #342.

This changes `Ioki::Model::Base` to only serialize those attributes, which were explicitly passed to the model.

The current behavior always serializes the whole object:

```ruby
irb(main):001> Ioki::Model::Operator::Line.new(slug: 'my-line').serialize
=>
{:type=>nil,
 :id=>nil,
 :created_at=>nil,
 :updated_at=>nil,
 :name=>nil,
 :mode=>nil,
 :route_number=>nil,
 :skip_time_window_check=>nil,
 :slug=>"my-line",
 :variant=>nil,
 :line_stops=>nil}
```

Using `omit_if_blank_on` or `omit_if_nil_on`, we can avoid serializing certain attributes. We cannot distinguish whether we want to send an attribute with the value `nil`, or not send the attribute at all.

This PR solves that issue. The new behavior only serializes the explicitly passed attributes:

```ruby
irb(main):001> Ioki::Model::Operator::Line.new(slug: 'my-line').serialize
=> {:slug=>"my-line"}
```

We achieve this by including `ActiveModel::Dirty` in `Ioki::Model::Base` and track changes whenever an attribute is set. The serialization then only serializes "dirty" (i.e. changed) attributes.

## Additional Changes

- Add `Ioki::Model::Base.changed_attributes` to return only changed attributes

## Caveats

- This is a breaking change, so we probably should increase our major version.
- If you don't want to send an attribute at all, but you already initialized it, you have to manually clear the dirty state. Example:

  ```ruby
  irb(main):002> line = Ioki::Model::Operator::Line.new(slug: 'my-line')
  => Ioki::Model::Operator::Line:3400 @attributes={:slug=>"my-line"}
  irb(main):003> line.serialize
  => {:slug=>"my-line"}

  # Now I notice that I don't want to send in `slug` at all.
  # I can't set it to `nil`, because then I would still send in `slug: nil`
  irb(main):007> line.slug = nil
  => nil
  irb(main):008> line.serialize
  => {:slug=>nil}

  # The correct way is to use the `ActiveModel::Dirty` API and clear the change state:
  irb(main):009> line.clear_slug_change
  => nil
  irb(main):010> line.serialize
  => {}
  ```
