### PR TITLE
Operator API | Allow to send `nil` as a `place_id` for task list pauses

### DIFF
--- a/lib/ioki/model/operator/pause.rb
+++ b/lib/ioki/model/operator/pause.rb
@@ -39,9 +39,8 @@ module Ioki
                   class_name: 'Place'
 
         attribute :place_id,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: :create,
-                  type:           :string
+                  on:   [:create, :read, :update],
+                  type: :string
 
         attribute :planned_ends_at,
                   on:   :read,


### PR DESCRIPTION
This allows to send in an explicit `nil` as a place for task list pauses in the operator API.