### PR TITLE
Operator Api | Add `admins_can_set_arbitrary_driver_password` to `Features` model

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -157,6 +157,10 @@ module Ioki
         attribute :driver_client_reconfirms_early_pickup_and_dropoff_completion?,
                   type: :boolean,
                   on:   :read
+
+        attribute :admins_can_set_arbitrary_driver_password,
+                  type: :boolean,
+                  on:   :read
       end
     end
   end


### PR DESCRIPTION
This PR will add the `admins_can_set_arbitrary_driver_password` attribute to the `Features` model for the operator api.