### PR TITLE
Passenger API | Fetch a single ride series

### DIFF
--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -138,6 +138,12 @@ module Ioki
         model_class: Ioki::Model::Passenger::RideSeries,
         only:        [:index]
       ),
+      Endpoints::Show.new(
+        :single_ride_series,
+        path:        'ride_series',
+        base_path:   [API_BASE_PATH],
+        model_class: Ioki::Model::Passenger::RideSeries
+      ),
       Endpoints.crud_endpoints(
         :station,
         base_path:   [API_BASE_PATH],

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -542,4 +542,15 @@ RSpec.describe Ioki::PassengerApi do
       expect(passenger_client.ride_series(options)).to all(be_a(Ioki::Model::Passenger::RideSeries))
     end
   end
+
+  describe '#single_ride_series(id)' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ride_series/0815')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.single_ride_series('0815', options)).to be_a Ioki::Model::Passenger::RideSeries
+    end
+  end
 end


### PR DESCRIPTION
This adds fetching of a single ride series from the passenger API.

The naming is unfortunate as there is no singular form of "ride series".