### PR TITLE
Operator Api | Fix `rematching_suggestions` endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -292,9 +292,10 @@ module Ioki
         model_class: Ioki::Model::Operator::RematchingAttempt,
         except:      [:update, :delete]
       ),
-      Endpoints::Index.new(
-        :rematching_suggestions,
-        base_path:   [API_BASE_PATH, 'products', :id, 'task_lists', :id],
+      Endpoints.custom_endpoints(
+        :task_list,
+        actions:     { 'rematching_suggestions' => :get },
+        path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
         model_class: Ioki::Model::Operator::RematchingSuggestion
       )
     ].freeze

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1508,15 +1508,15 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#rematching_suggestions(product_id, task_list_id)' do
+  describe '#task_list_rematching_suggestions(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('operator/products/0815/task_lists/4711/rematching_suggestions')
         result_with_index_data
       end
 
-      expect(operator_client.rematching_suggestions('0815', '4711', options))
-        .to all(be_a(Ioki::Model::Operator::RematchingSuggestion))
+      expect(operator_client.task_list_rematching_suggestions('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::RematchingSuggestion)
     end
   end
 end


### PR DESCRIPTION
This PR will fix the rematching_suggestions endpoint.