### PR TITLE
Operator Api | Add `fleet_state` endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -300,7 +300,7 @@ module Ioki
       ),
       Endpoints::ShowSingular.new(
         :fleet_state,
-        base_path:        [API_BASE_PATH],
+        base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Operator::Vehicle
       )
     ].freeze

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -110,6 +110,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'products', :id, 'task_lists'],
         model_class: Ioki::Model::Operator::TaskList
       ),
+      Endpoints::Index.new(
+        :task_list_overview,
+        base_path:   [API_BASE_PATH, 'products', :id, 'task_lists'],
+        path:        'overview',
+        model_class: Ioki::Model::Operator::TaskList
+      ),
       Endpoints.custom_endpoints(
         'task_lists',
         actions:     { 'current_journey' => :get },

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -301,7 +301,7 @@ module Ioki
       Endpoints::ShowSingular.new(
         :fleet_state,
         base_path:   [API_BASE_PATH],
-        model_class: Ioki::Model::Operator::Vehicle
+        model_class: Ioki::Model::Operator::FleetState
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -297,6 +297,11 @@ module Ioki
         actions:     { 'rematching_suggestions' => :get },
         path:        [API_BASE_PATH, 'products', :id, 'task_lists', :id],
         model_class: Ioki::Model::Operator::RematchingSuggestion
+      ),
+      Endpoints::ShowSingular.new(
+        :fleet_state,
+        base_path:        [API_BASE_PATH],
+        model_class: Ioki::Model::Operator::Vehicle
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/fleet_state.rb
+++ b/lib/ioki/model/operator/fleet_state.rb
@@ -11,7 +11,7 @@ module Ioki
         attribute :vehicles,
                   on:         :read,
                   type:       :array,
-                  class_name: 'TaskList'
+                  class_name: 'Vehicle'
       end
     end
   end

--- a/lib/ioki/model/operator/fleet_state.rb
+++ b/lib/ioki/model/operator/fleet_state.rb
@@ -4,7 +4,14 @@ module Ioki
   module Model
     module Operator
       class FleetState < Base
-        base 'Array', item_class_name: 'Vehicle'
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :vehicles,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'TaskList'
       end
     end
   end

--- a/lib/ioki/model/operator/fleet_state.rb
+++ b/lib/ioki/model/operator/fleet_state.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class FleetState < Base
+        base 'Array', item_class_name: 'Vehicle'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -106,10 +106,6 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :string
 
-        attribute :product_id,
-                  on:   :read,
-                  type: :string
-
         deprecated_attribute :seats,
                              on:             [:create, :read, :update],
                              omit_if_nil_on: [:create, :update],

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -20,6 +20,10 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
+        attribute :active,
+                  on:   :read,
+                  type: :boolean
+
         attribute :autonomous,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],
@@ -100,6 +104,10 @@ module Ioki
 
         attribute :phone_number,
                   on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :product_id,
+                  on:   :read,
                   type: :string
 
         deprecated_attribute :seats,

--- a/spec/ioki/model/operator/vehicle_spec.rb
+++ b/spec/ioki/model/operator/vehicle_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Ioki::Model::Operator::Vehicle do
   it { is_expected.to define_attribute(:created_at).as(:date_time) }
   it { is_expected.to define_attribute(:updated_at).as(:date_time) }
   it { is_expected.to define_attribute(:version).as(:integer) }
+  it { is_expected.to define_attribute(:active).as(:boolean) }
   it { is_expected.to define_attribute(:autonomous).as(:boolean) }
   it { is_expected.to define_attribute(:connected_driver_id).as(:string) }
 
@@ -28,6 +29,7 @@ RSpec.describe Ioki::Model::Operator::Vehicle do
   it { is_expected.to define_attribute(:num_wheelchair_bays_as_storages).as(:integer) }
   it { is_expected.to define_attribute(:operator_id).as(:string) }
   it { is_expected.to define_attribute(:phone_number).as(:string) }
+  it { is_expected.to define_attribute(:product_id).as(:string) }
   it { is_expected.to define_attribute(:seats).as(:integer) }
   it { is_expected.to define_attribute(:storage_spaces).as(:integer) }
   it { is_expected.to define_attribute(:walker_bays).as(:integer) }

--- a/spec/ioki/model/operator/vehicle_spec.rb
+++ b/spec/ioki/model/operator/vehicle_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Ioki::Model::Operator::Vehicle do
   it { is_expected.to define_attribute(:num_wheelchair_bays_as_storages).as(:integer) }
   it { is_expected.to define_attribute(:operator_id).as(:string) }
   it { is_expected.to define_attribute(:phone_number).as(:string) }
-  it { is_expected.to define_attribute(:product_id).as(:string) }
   it { is_expected.to define_attribute(:seats).as(:integer) }
   it { is_expected.to define_attribute(:storage_spaces).as(:integer) }
   it { is_expected.to define_attribute(:walker_bays).as(:integer) }

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -652,6 +652,18 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#task_list_overview(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/task_lists/overview')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.task_list_overview('0815', options))
+        .to all(be_a(Ioki::Model::Operator::TaskList))
+    end
+  end
+
   describe '#pauses(product_id, task_list_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1519,4 +1519,15 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::RematchingSuggestion)
     end
   end
+
+  describe '#fleet_state' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/fleet_state')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.fleet_state(options)).to be_a Ioki::Model::Operator::Vehicle
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1527,7 +1527,7 @@ RSpec.describe Ioki::OperatorApi do
         [result_with_data, full_response]
       end
 
-      expect(operator_client.fleet_state(options)).to be_a Ioki::Model::Operator::Vehicle
+      expect(operator_client.fleet_state(options)).to be_a Ioki::Model::Operator::FleetState
     end
   end
 end


### PR DESCRIPTION
Make the fleet_state endpoint accessible for the operator api. And add the `task_list_overview` endpoint.
This will replace the `monitoring` and `vehicle_plannings` endpoint 👍 (which will be removed in a followup PR) 