### PR TITLE
Platform API | Add `Product#default_map_bounding_box`

### DIFF
--- a/lib/ioki/model/platform/product.rb
+++ b/lib/ioki/model/platform/product.rb
@@ -36,6 +36,7 @@ module Ioki
         attribute :announcements, on: :read, type: :array, class_name: 'Announcement'
         deprecated_attribute :area, type: :object, on: :read, class_name: 'GeoJson'
         attribute :bounding_box, on: :read, type: :object, class_name: 'BoundingBox'
+        attribute :default_map_bounding_box, on: :read, type: :object, class_name: 'BoundingBox'
         attribute :features, on: :read, type: :object, class_name: 'ProductFeatures'
         attribute :driver_cancellation_statements, on: :read, type: :array, class_name: 'CancellationStatement'
         attribute :passenger_cancellation_statements, on: :read, type: :array, class_name: 'CancellationStatement'


### PR DESCRIPTION
Adds `Product#default_map_bounding_box` to the platform API.