### PR TITLE
Config | Proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ and api_client_secret. You can setup these ENV variables:
   ENV['IOKI_RETRY_COUNT']
   ENV['IOKI_RETRY_SLEEP_SECONDS']
   ENV['IOKI_IGNORE_DEPRECATED_ATTRIBUTES']
+  ENV['IOKI_PROXY_URL']
+  ENV['IOKI_VERIFY_SSL']
 ```
 
 or define them for one of the three supported apis with a prefix:

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ and api_client_secret. You can setup these ENV variables:
   ENV['IOKI_OAUTH_APP_URL']
   ENV['IOKI_RETRY_COUNT']
   ENV['IOKI_RETRY_SLEEP_SECONDS']
+  ENV['IOKI_IGNORE_DEPRECATED_ATTRIBUTES']
 ```
 
 or define them for one of the three supported apis with a prefix:

--- a/lib/ioki/configuration.rb
+++ b/lib/ioki/configuration.rb
@@ -11,7 +11,9 @@ module Ioki
         logger_options:               { headers: true, bodies: false, log_level: :info },
         retry_count:                  3,
         retry_sleep_seconds:          1,
-        ignore_deprecated_attributes: false
+        ignore_deprecated_attributes: false,
+        proxy_url:                    nil,
+        verify_ssl:                   true
       }.freeze
 
     CONFIG_KEYS = [
@@ -34,7 +36,9 @@ module Ioki
       :oauth_token_callback,
       :retry_count,
       :retry_sleep_seconds,
-      :ignore_deprecated_attributes
+      :ignore_deprecated_attributes,
+      :proxy_url,
+      :verify_ssl
     ].freeze
 
     attr_accessor(*CONFIG_KEYS)
@@ -61,6 +65,8 @@ module Ioki
       @retry_count = params[:retry_count]
       @retry_sleep_seconds = params[:retry_sleep_seconds]
       @ignore_deprecated_attributes = params[:ignore_deprecated_attributes]
+      @proxy_url = params[:proxy_url]
+      @verify_ssl = params[:verify_ssl]
       # you can pass in a custom Faraday::Connection instance:
       @http_adapter = params[:http_adapter] || Ioki::HttpAdapter.get(self)
       @custom_http_adapter = !!params[:http_adapter]
@@ -93,7 +99,9 @@ module Ioki
         oauth_app_url:                ENV.fetch("#{prefix}_OAUTH_APP_URL", nil),
         retry_count:                  ENV.fetch("#{prefix}_RETRY_COUNT", nil),
         retry_sleep_seconds:          ENV.fetch("#{prefix}_RETRY_SLEEP_SECONDS", nil),
-        ignore_deprecated_attributes: ENV.fetch("#{prefix}_IGNORE_DEPRECATED_ATTRIBUTES", nil)
+        ignore_deprecated_attributes: ENV.fetch("#{prefix}_IGNORE_DEPRECATED_ATTRIBUTES", nil),
+        proxy_url:                    ENV.fetch("#{prefix}_PROXY_URL", nil),
+        verify_ssl:                   ENV.fetch("#{prefix}_VERIFY_SSL", 'true')&.downcase == 'true'
       }.reject { |_key, value| value.nil? || value.to_s == '' }
     end
 

--- a/lib/ioki/http_adapter.rb
+++ b/lib/ioki/http_adapter.rb
@@ -7,7 +7,13 @@ module Ioki
   class HttpAdapter
 
     def self.get(config)
-      ::Faraday.new(config.api_base_url, headers: headers(config)) do |f|
+      options = {
+        proxy:   config.proxy_url,
+        ssl:     { verify: config.verify_ssl },
+        headers: headers(config)
+      }
+
+      ::Faraday.new(config.api_base_url, options) do |f|
         f.adapter :net_http
 
         f.request :authorization, 'Bearer', -> { config.token }

--- a/spec/ioki/configuration_spec.rb
+++ b/spec/ioki/configuration_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe Ioki::Configuration do
       :oauth_token_callback,
       :retry_count,
       :retry_sleep_seconds,
-      :ignore_deprecated_attributes
+      :ignore_deprecated_attributes,
+      :proxy_url,
+      :verify_ssl
     )
   end
 
@@ -52,6 +54,7 @@ RSpec.describe Ioki::Configuration do
   describe 'default values and resetting' do
     before do
       allow(ENV).to receive(:fetch).and_return(nil)
+      allow(ENV).to receive(:fetch).with('IOKI_VERIFY_SSL', anything).and_return('true')
       stub_const(
         'EXPECTED_DEFAULTS',
         {
@@ -66,7 +69,9 @@ RSpec.describe Ioki::Configuration do
           logger_options:               described_class::DEFAULT_VALUES[:logger_options],
           retry_count:                  3,
           retry_sleep_seconds:          1,
-          ignore_deprecated_attributes: false
+          ignore_deprecated_attributes: false,
+          proxy_url:                    nil,
+          verify_ssl:                   true
         }.freeze
       )
     end
@@ -89,7 +94,8 @@ RSpec.describe Ioki::Configuration do
 
           expect { config.reset! }.to change {
             config.send(attribute)
-          }.from(:dummy_value).to(EXPECTED_DEFAULTS[attribute])
+          }.from(:dummy_value).to(EXPECTED_DEFAULTS[attribute]),
+                                      "#{attribute} was expected to change to #{EXPECTED_DEFAULTS[attribute]}"
         end
       end
     end


### PR DESCRIPTION
This adds support for proxy settings.

Set the following env variables:

```
export IOKI_PROXY_URL=http://localhost:8080
export IOKI_VERIFY_SSL=false
```

And start a development proxy on port 8080, e.g. `mitmweb`. All requests are now proxied through there for easier inspection.