### PR TITLE
Platform API | Add `ProviderFeatures#tickets`

### DIFF
--- a/lib/ioki/model/platform/provider_features.rb
+++ b/lib/ioki/model/platform/provider_features.rb
@@ -13,6 +13,7 @@ module Ioki
         attribute :promo_codes, type: :boolean, on: :read
         attribute :newsletter, type: :boolean, on: :read
         attribute :receipts, type: :boolean, on: :read
+        attribute :tickets, type: :boolean, on: :read
       end
     end
   end


### PR DESCRIPTION
This adds the `tickets` feature flags for providers on the platform API.