### PR TITLE
Passenger API | Ticketing

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -29,7 +29,7 @@ module Ioki
       def call(client, model, args = [], options = {})
         outgoing_model_class = @outgoing_model_class || options[:outgoing_model_class] || model_class
 
-        unless model.blank? || model.is_a?(outgoing_model_class)
+        unless @outgoing_model_class == :empty || model.is_a?(outgoing_model_class)
           raise(ArgumentError, "#{model} is not an instance of #{outgoing_model_class}")
         end
 

--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -29,14 +29,14 @@ module Ioki
       def call(client, model, args = [], options = {})
         outgoing_model_class = @outgoing_model_class || options[:outgoing_model_class] || model_class
 
-        unless model.is_a?(outgoing_model_class)
+        unless model.blank? || model.is_a?(outgoing_model_class)
           raise(ArgumentError, "#{model} is not an instance of #{outgoing_model_class}")
         end
 
         parsed_response, response = client.request(
           url:    client.build_request_url(*Endpoints.url_elements(full_path, *args)),
           method: :post,
-          body:   { data: model.serialize(:create) },
+          body:   { data: model&.serialize(:create) },
           params: options[:params]
         )
 

--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -230,6 +230,41 @@ module Ioki
         base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Passenger::RedeemedPromoCode,
         only:        [:index, :create]
+      ),
+      Endpoints.crud_endpoints(
+        :ticketing_voucher,
+        base_path:   [API_BASE_PATH, 'ticketing'],
+        paths:       { index: 'vouchers', show: 'vouchers' },
+        model_class: Ioki::Model::Passenger::Ticketing::Voucher,
+        only:        [:index, :show]
+      ),
+      Endpoints::Create.new(
+        :ticketing_voucher_renewal,
+        base_path:            [API_BASE_PATH, 'ticketing', 'vouchers', :id],
+        path:                 'renewal',
+        model_class:          Ioki::Model::Passenger::Ticketing::Voucher,
+        outgoing_model_class: Ioki::Model::Passenger::Ticketing::VoucherRenewal
+      ),
+      Endpoints::Create.new(
+        :ticketing_voucher_subscription_cancellation,
+        base_path:            [API_BASE_PATH, 'ticketing', 'vouchers', :id],
+        path:                 'subscription_cancellation',
+        model_class:          Ioki::Model::Passenger::Ticketing::Voucher,
+        outgoing_model_class: nil
+      ),
+      Endpoints.crud_endpoints(
+        :ticketing_product,
+        base_path:   [API_BASE_PATH, 'ticketing'],
+        paths:       { index: 'products', show: 'products' },
+        model_class: Ioki::Model::Passenger::Ticketing::Product,
+        only:        [:index, :show]
+      ),
+      Endpoints::Create.new(
+        :ticketing_product_purchase,
+        base_path:            [API_BASE_PATH, 'ticketing', 'products', :id],
+        path:                 'purchase',
+        model_class:          Ioki::Model::Passenger::Ticketing::Voucher,
+        outgoing_model_class: Ioki::Model::Passenger::Ticketing::ProductPurchase
       )
     ].freeze
   end

--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -250,7 +250,7 @@ module Ioki
         base_path:            [API_BASE_PATH, 'ticketing', 'vouchers', :id],
         path:                 'subscription_cancellation',
         model_class:          Ioki::Model::Passenger::Ticketing::Voucher,
-        outgoing_model_class: nil
+        outgoing_model_class: :empty
       ),
       Endpoints.crud_endpoints(
         :ticketing_product,

--- a/lib/ioki/model.rb
+++ b/lib/ioki/model.rb
@@ -10,8 +10,9 @@ require 'ioki/model/webhooks/base'
 Dir[File.join(__dir__, 'model', 'platform', '*')].reject do |filename|
   filename == File.join(__dir__, 'model', 'platform', 'base.rb')
 end.sort.each { |file| require file }
-Dir[File.join(__dir__, 'model', 'passenger', '*')].reject do |filename|
-  filename == File.join(__dir__, 'model', 'passenger', 'base.rb')
+Dir[File.join(__dir__, 'model', 'passenger', '**', '*')].reject do |filename|
+  filename == File.join(__dir__, 'model', 'passenger', 'base.rb') ||
+    !File.file?(filename)
 end.sort.each { |file| require file }
 Dir[File.join(__dir__, 'model', 'driver', '*')].reject do |filename|
   filename == File.join(__dir__, 'model', 'driver', 'base.rb')

--- a/lib/ioki/model/passenger/enum_item.rb
+++ b/lib/ioki/model/passenger/enum_item.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class EnumItem < Base
+        attribute :type, on: :read, type: :string
+        attribute :slug, on: :read, type: :string
+        attribute :name, on: :read, type: :string
+        attribute :description, on: :read, type: :string
+        attribute :value, on: :read, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/option_value.rb
+++ b/lib/ioki/model/passenger/ticketing/option_value.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class OptionValue < Base
+          attribute :type, on: :read, type: :string
+          attribute :slug, on: :read, type: :string
+          attribute :value, on: :read, type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/product.rb
+++ b/lib/ioki/model/passenger/ticketing/product.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class Product < Base
+          attribute :type, on: :read, type: :string
+          attribute :id, on: :read, type: :string
+          attribute :created_at, on: :read, type: :date_time
+          attribute :updated_at, on: :read, type: :date_time
+          attribute :provider_id, on: :read, type: :string
+          attribute :ticketing_vendor_id, on: :read, type: :string
+          attribute :slug, on: :read, type: :string
+          attribute :name, on: :read, type: :string
+          attribute :description, on: :read, type: :string
+          attribute :purchasable, on: :read, type: :boolean
+          attribute :purchasable_from, on: :read, type: :date_time
+          attribute :purchasable_until, on: :read, type: :date_time
+          attribute :price_type, on: :read, type: :string
+          attribute :icon_type, on: :read, type: :string
+          attribute :price, on: :read, type: :object, class_name: 'Ioki::Model::Passenger::Money'
+          attribute :purchase_options, on: :read, type: :array, class_name: 'PurchaseOption'
+          attribute :redemption_options, on: :read, type: :array, class_name: 'RedemptionOption'
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/product_purchase.rb
+++ b/lib/ioki/model/passenger/ticketing/product_purchase.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class ProductPurchase < Base
+          attribute :purchase_options, on: :create, type: :array, class_name: 'PurchaseOption'
+          attribute :redemption_options, on: :create, type: :array, class_name: 'RedemptionOption'
+          attribute :ride_id, on: :create, type: :string
+          attribute :payment_method, on: :create, type: :object, class_name: 'Ioki::Model::Passenger::PaymentMethod'
+          attribute :paypal_secure_element, on: :create, type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/purchase_option.rb
+++ b/lib/ioki/model/passenger/ticketing/purchase_option.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class PurchaseOption < Base
+          attribute :type, on: :read, type: :string
+          attribute :slug, on: [:read, :create], type: :string
+          attribute :name, on: :read, type: :string
+          attribute :description, on: :read, type: :string
+          attribute :data_type, on: :read, type: :string
+          attribute :data_format, on: :read, type: :string
+          attribute :data_enum, on: :read, type: :boolean
+          attribute :required, on: :read, type: :boolean
+          attribute :enum_items, on: :read, type: :array, class_name: 'Ioki::Model::Passenger::EnumItem'
+          attribute :value, on: :create, type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/redemption_option.rb
+++ b/lib/ioki/model/passenger/ticketing/redemption_option.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class RedemptionOption < Base
+          attribute :type, on: :read, type: :string
+          attribute :slug, on: [:read, :create], type: :string
+          attribute :name, on: :read, type: :string
+          attribute :description, on: :read, type: :string
+          attribute :data_type, on: :read, type: :string
+          attribute :data_format, on: :read, type: :string
+          attribute :data_enum, on: :read, type: :boolean
+          attribute :required, on: :read, type: :boolean
+          attribute :enum_items, on: :read, type: :array, class_name: 'Ioki::Model::Passenger::EnumItem'
+          attribute :value, on: :create, type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/ticket.rb
+++ b/lib/ioki/model/passenger/ticketing/ticket.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class Ticket < Base
+          attribute :type, on: :read, type: :string
+          attribute :id, on: :read, type: :string
+          attribute :created_at, on: :read, type: :date_time
+          attribute :updated_at, on: :read, type: :date_time
+          attribute :voucher_id, on: :read, type: :string
+          attribute :issuer_slug, on: :read, type: :string
+          attribute :access_token, on: :read, type: :string
+          attribute :webview_url, on: :read, type: :string
+          attribute :validity_information, on: :read, type: :string
+          attribute :valid_from, on: :read, type: :date_time
+          attribute :valid_until, on: :read, type: :date_time
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/voucher.rb
+++ b/lib/ioki/model/passenger/ticketing/voucher.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class Voucher < Base
+          attribute :type, on: :read, type: :string
+          attribute :id, on: :read, type: :string
+          attribute :created_at, on: :read, type: :date_time
+          attribute :updated_at, on: :read, type: :date_time
+          attribute :provider_id, on: :read, type: :string
+          attribute :user_id, on: :read, type: :string
+          attribute :ride_id, on: :read, type: :string
+          attribute :state, on: :read, type: :string
+          attribute :product, on: :read, type: :object, class_name: 'Product'
+          attribute :ticket, on: :read, type: :object, class_name: 'Ticket'
+          attribute :payment_method, on: :read, type: :object, class_name: 'Ioki::Model::Passenger::PaymentMethod'
+          attribute :price, on: :read, type: :object, class_name: 'Ioki::Model::Passenger::Money'
+          attribute :purchase_option_values, on: :read, type: :array, class_name: 'OptionValue'
+          attribute :redemption_option_values, on: :read, type: :array, class_name: 'OptionValue'
+          attribute :renewal_information, on: :read, type: :object, class_name: 'VoucherRenewalInformation'
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/voucher_renewal.rb
+++ b/lib/ioki/model/passenger/ticketing/voucher_renewal.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class VoucherRenewal < Base
+          attribute :payment_method, on: :create, type: :object, class_name: 'Ioki::Model::Passenger::PaymentMethod'
+          attribute :paypal_secure_element, on: :create, type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/ticketing/voucher_renewal_information.rb
+++ b/lib/ioki/model/passenger/ticketing/voucher_renewal_information.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      module Ticketing
+        class VoucherRenewalInformation < Base
+          attribute :type, on: :read, type: :string
+          attribute :renewable, on: :read, type: :boolean
+          attribute :valid_from, on: :read, type: :date_time
+          attribute :valid_until, on: :read, type: :date_time
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -553,4 +553,88 @@ RSpec.describe Ioki::PassengerApi do
       expect(passenger_client.single_ride_series('0815', options)).to be_a Ioki::Model::Passenger::RideSeries
     end
   end
+
+  describe '#ticketing_vouchers' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/vouchers')
+        result_with_index_data
+      end
+
+      expect(passenger_client.ticketing_vouchers(options)).to all(be_a(Ioki::Model::Passenger::Ticketing::Voucher))
+    end
+  end
+
+  describe '#ticketing_voucher' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/vouchers/0815')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.ticketing_voucher('0815', options)).to be_a(Ioki::Model::Passenger::Ticketing::Voucher)
+    end
+  end
+
+  describe '#create_ticketing_voucher_renewal' do
+    let(:voucher_renewal) { Ioki::Model::Passenger::Ticketing::VoucherRenewal.new }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/vouchers/0815/renewal')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_ticketing_voucher_renewal('0815', voucher_renewal, options))
+        .to be_a Ioki::Model::Passenger::Ticketing::Voucher
+    end
+  end
+
+  describe '#create_ticketing_voucher_subscription_cancellation' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/vouchers/0815/subscription_cancellation')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_ticketing_voucher_subscription_cancellation('0815', nil, options))
+        .to be_a Ioki::Model::Passenger::Ticketing::Voucher
+    end
+  end
+
+  describe '#ticketing_products' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/products')
+        result_with_index_data
+      end
+
+      expect(passenger_client.ticketing_products(options)).to all(be_a(Ioki::Model::Passenger::Ticketing::Product))
+    end
+  end
+
+  describe '#ticketing_product' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/products/0815')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.ticketing_product('0815', options)).to be_a(Ioki::Model::Passenger::Ticketing::Product)
+    end
+  end
+
+  describe '#create_ticketing_product_purchase' do
+    let(:purchase) { Ioki::Model::Passenger::Ticketing::ProductPurchase.new }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/ticketing/products/0815/purchase')
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_ticketing_product_purchase('0815', purchase, options))
+        .to be_a Ioki::Model::Passenger::Ticketing::Voucher
+    end
+  end
 end


### PR DESCRIPTION
This adds all model and endpoints related to ticketing to the passenger API.

There are also two additional changes:

- Add support for namespaced models to the passenger API. Currently all model classes of the passenger API are located in `Ioki::Model::Passenger`. For Ticketing it makes sense to namespace all ticketing models in `Ioki::Model::Passenger::Ticketing`. Such subfolders were not yet loaded though (in `lib/ioki/model.rb`).
- Allow `POST` requests with an empty body. You still have to pass `nil` to the method though: `passenger_client.create_my_model('my_id', nil)`