### PR TITLE
Add `service_starts_at` and `service_ends_at` to TaskList model

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -92,6 +92,14 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :boolean
 
+        attribute :service_ends_at,
+                  on:   [:create, :read, :update],
+                  type: :date_time
+
+        attribute :service_starts_at,
+                  on:   [:create, :read, :update],
+                  type: :date_time
+
         attribute :start_location,
                   on:         :read,
                   type:       :object,

--- a/lib/ioki/model/platform/task_list.rb
+++ b/lib/ioki/model/platform/task_list.rb
@@ -24,6 +24,8 @@ module Ioki
         attribute :planned_starts_at, on: :read, type: :date_time
         attribute :prebookable, on: [:read, :create], type: :boolean
         attribute :product_id, on: :read, type: :string
+        attribute :service_ends_at, on: [:create, :read, :update], type: :date_time
+        attribute :service_starts_at, on: [:create, :read, :update], type: :date_time
         attribute :starts_at, on: [:create, :update], type: :date_time, unvalidated: true
         attribute :start_place, on: :read, type: :object, class_name: 'Place'
         attribute :start_place_id, on: [:create, :update], type: :object, class_name: 'Place', unvalidated: true

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:planned_ends_at).as(:date_time) }
     it { is_expected.to define_attribute(:planned_starts_at).as(:date_time) }
     it { is_expected.to define_attribute(:prebookable).as(:boolean) }
+    it { is_expected.to define_attribute(:service_ends_at).as(:date_time) }
+    it { is_expected.to define_attribute(:service_starts_at).as(:date_time) }
     it { is_expected.to define_attribute(:start_location).as(:object).with(class_name: %w[Place Station]) }
     it { is_expected.to define_attribute(:start_location_id).as(:string) }
     it { is_expected.to define_attribute(:start_location_type).as(:string) }


### PR DESCRIPTION
This PR will add the attributes `service_starts_at` and `service_ends_at` to the TaskList model of the operator api and platform api.