### PR TITLE
Operator Api | Add attributes to `MatchingConfiguration`

### DIFF
--- a/lib/ioki/model/operator/matching_configuration.rb
+++ b/lib/ioki/model/operator/matching_configuration.rb
@@ -97,6 +97,16 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :integer
 
+        attribute :max_walking_duration_dropoff,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
+
+        attribute :max_walking_duration_pickup,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :integer
+
         attribute :maximum_detour_duration,
                   on:   [:create, :read, :update],
                   type: :integer


### PR DESCRIPTION
This PR will add the attributes `max_walking_duration_pickup` and `max_walking_duration_dropoff` to the `MatchingConfiguration` model.