### PR TITLE
Operator Api | Change access for `default_resource_configuration`

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -115,6 +115,26 @@ module Ioki
                   on:             [:update, :read],
                   omit_if_nil_on: [:update],
                   type:           :integer
+
+        deprecated_attribute :seats,
+                             on:             [:create, :read, :update],
+                             omit_if_nil_on: [:create, :update],
+                             type:           :integer
+
+        deprecated_attribute :storage_spaces,
+                             on:             [:create, :read, :update],
+                             omit_if_nil_on: [:create, :update],
+                             type:           :integer
+
+        deprecated_attribute :walker_bays,
+                             on:             [:create, :read, :update],
+                             omit_if_nil_on: [:create, :update],
+                             type:           :integer
+
+        deprecated_attribute :wheelchair_bays,
+                             on:             [:create, :read, :update],
+                             omit_if_nil_on: [:create, :update],
+                             type:           :integer
       end
     end
   end

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -34,7 +34,7 @@ module Ioki
                   type: :string
 
         attribute :default_resource_configuration,
-                  on:         :read,
+                  on:         [:create, :read, :update],
                   type:       :object,
                   class_name: 'ResourceConfiguration'
 

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -106,26 +106,6 @@ module Ioki
                   on:   [:create, :read, :update],
                   type: :string
 
-        deprecated_attribute :seats,
-                             on:             [:create, :read, :update],
-                             omit_if_nil_on: [:create, :update],
-                             type:           :integer
-
-        deprecated_attribute :storage_spaces,
-                             on:             [:create, :read, :update],
-                             omit_if_nil_on: [:create, :update],
-                             type:           :integer
-
-        deprecated_attribute :walker_bays,
-                             on:             [:create, :read, :update],
-                             omit_if_nil_on: [:create, :update],
-                             type:           :integer
-
-        deprecated_attribute :wheelchair_bays,
-                             on:             [:create, :read, :update],
-                             omit_if_nil_on: [:create, :update],
-                             type:           :integer
-
         attribute :telemetry,
                   on:         :read,
                   type:       :object,

--- a/lib/ioki/model/platform/vehicle.rb
+++ b/lib/ioki/model/platform/vehicle.rb
@@ -28,6 +28,11 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :default_resource_configuration,
+                  on:         [:create, :read, :update],
+                  type:       :object,
+                  class_name: 'ResourceConfiguration'
+
         attribute :description,
                   on:   [:read, :create, :update],
                   type: :string
@@ -70,28 +75,12 @@ module Ioki
                   on:   [:read, :create, :update],
                   type: :string
 
-        attribute :seats,
-                  on:   [:read, :create, :update],
-                  type: :integer
-
-        attribute :storage_spaces,
-                  on:   [:read, :create, :update],
-                  type: :integer
-
         attribute :vehicle_type,
                   on:   [:read, :create, :update],
                   type: :string
 
         attribute :version,
                   on:   [:read, :update],
-                  type: :integer
-
-        attribute :walker_bays,
-                  on:   [:read, :create, :update],
-                  type: :integer
-
-        attribute :wheelchair_bays,
-                  on:   [:read, :create, :update],
                   type: :integer
       end
     end

--- a/spec/ioki/model/operator/vehicle_spec.rb
+++ b/spec/ioki/model/operator/vehicle_spec.rb
@@ -29,9 +29,5 @@ RSpec.describe Ioki::Model::Operator::Vehicle do
   it { is_expected.to define_attribute(:num_wheelchair_bays_as_storages).as(:integer) }
   it { is_expected.to define_attribute(:operator_id).as(:string) }
   it { is_expected.to define_attribute(:phone_number).as(:string) }
-  it { is_expected.to define_attribute(:seats).as(:integer) }
-  it { is_expected.to define_attribute(:storage_spaces).as(:integer) }
-  it { is_expected.to define_attribute(:walker_bays).as(:integer) }
-  it { is_expected.to define_attribute(:wheelchair_bays).as(:integer) }
   it { is_expected.to define_attribute(:telemetry).as(:object).with(class_name: 'Telemetry') }
 end


### PR DESCRIPTION
Add `create` and `update` access for the attribute `default_resource_configuration` of the Vehicle model.