### PR TITLE
Operator Api | Add endpoints for `Zone`

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -313,7 +313,7 @@ module Ioki
         :zone,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::Zone
-      ),
+      )
     ].freeze
   end
 end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -308,7 +308,12 @@ module Ioki
         :fleet_state,
         base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Operator::FleetState
-      )
+      ),
+      Endpoints.crud_endpoints(
+        :zone,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::Zone
+      ),
     ].freeze
   end
 end

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -6,15 +6,14 @@ module Ioki
       class Geojson < Base
         unvalidated true
 
-        attribute :coordinates, type: :array, on: [:create, :read]
-        attribute :type, type: :string, on: [:create, :read]
+        attribute :coordinates, type: :array, on: [:create, :read, :update]
+        attribute :type, type: :string, on: [:create, :read, :update]
 
         def serialize(usecase = :read, only_changed: true)
           case usecase
-          when :read
-            super
-          when :create
-            { coordinates:, type: }.to_json
+          when :read then super
+          else @_raw_attributes.to_json
+          # else { coordinates:, type: }.to_json
           end
         end
       end

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -14,7 +14,7 @@ module Ioki
           when :read
             super
           when :create
-            { coordinates: }.to_json
+            { coordinates:, type: }.to_json
           end
         end
       end

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -8,6 +8,15 @@ module Ioki
 
         attribute :coordinates, type: :array, on: [:create, :read]
         attribute :type, type: :string, on: [:create, :read]
+
+        def serialize(usecase = :read, only_changed: true)
+          case usecase
+          when :read
+            super
+          when :create
+            { coordinates: }.to_json
+          end
+        end
       end
     end
   end

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -6,8 +6,8 @@ module Ioki
       class Geojson < Base
         unvalidated true
 
-        attribute :coordinates, type: :array, on: :read
-        attribute :type, type: :string, on: :read
+        attribute :coordinates, type: :array, on: [:create, :read]
+        attribute :type, type: :string, on: [:create, :read]
       end
     end
   end

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -13,7 +13,6 @@ module Ioki
           case usecase
           when :read then super
           else @_raw_attributes.to_json
-          # else { coordinates:, type: }.to_json
           end
         end
       end

--- a/lib/ioki/model/operator/zone.rb
+++ b/lib/ioki/model/operator/zone.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Zone < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :area,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Geojson'
+
+        attribute :area_geojson,
+                  on:   [:create, :update],
+                  type: :string
+
+        attribute :inverted_area,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Geojson'
+
+        attribute :name,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :slug,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/zone.rb
+++ b/lib/ioki/model/operator/zone.rb
@@ -20,17 +20,8 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
-        attribute :area,
-                  on:         :read,
-                  type:       :object,
-                  class_name: 'Geojson'
-
         attribute :area_geojson,
-                  on:   [:create, :update],
-                  type: :string
-
-        attribute :inverted_area,
-                  on:         :read,
+                  on:         [:create, :read, :update],
                   type:       :object,
                   class_name: 'Geojson'
 

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1542,4 +1542,71 @@ RSpec.describe Ioki::OperatorApi do
       expect(operator_client.fleet_state(options)).to be_a Ioki::Model::Operator::FleetState
     end
   end
+
+  describe '#zones(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/zones')
+        result_with_index_data
+      end
+
+      expect(operator_client.zones('0815', options))
+        .to all(be_a(Ioki::Model::Operator::Zone))
+    end
+  end
+
+  describe '#zone(product_id, zone_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/zones/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.zone('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::Zone)
+    end
+  end
+
+  describe '#create_zone(product_id, zone)' do
+    let(:zone) { Ioki::Model::Operator::Zone.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/zones')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_zone('0815', zone, options))
+        .to be_a(Ioki::Model::Operator::Zone)
+    end
+  end
+
+  describe '#update_zone(product_id, zone)' do
+    let(:zone) { Ioki::Model::Operator::Zone.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/zones/4711')
+        expect(params[:method]).to eq(:patch)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_zone('0815', zone, options))
+        .to be_a(Ioki::Model::Operator::Zone)
+    end
+  end
+
+  describe '#delete_zone(product_id, zone_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/zones/4711')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_zone('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::Zone)
+    end
+  end
 end


### PR DESCRIPTION
This adds the endpoints for `Zones` and the `Zone` model for the operator api.