### PR TITLE
Operator Api | Remove update access for `area_type`

### DIFF
--- a/lib/ioki/model/operator/area.rb
+++ b/lib/ioki/model/operator/area.rb
@@ -31,8 +31,8 @@ module Ioki
                   type:           :string
 
         attribute :area_type,
-                  on:             [:create, :read, :update],
-                  omit_if_nil_on: [:create, :update],
+                  on:             [:create, :read],
+                  omit_if_nil_on: [:create],
                   type:           :string
 
         attribute :description,


### PR DESCRIPTION
As the title suggests, this PR will remove `update` access from the `area_type` attribute for the operator api.