### PR TITLE
Operator Api | Add creator_id and creator_type to Ride model

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -55,6 +55,14 @@ module Ioki
                   type:       :object,
                   class_name: 'CancellationStatement'
 
+        attribute :creator_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :creator_type,
+                  on:   :read,
+                  type: :string
+
         attribute :destination,
                   on:         :read,
                   type:       :object,

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:cancellation_reason).as(:string) }
   it { is_expected.to define_attribute(:cancellation_reason_translated).as(:string) }
   it { is_expected.to define_attribute(:cancellation_statement).as(:object).with(class_name: 'CancellationStatement') }
+  it { is_expected.to define_attribute(:creator_id).as(:string) }
+  it { is_expected.to define_attribute(:creator_type).as(:string) }
   it { is_expected.to define_attribute(:destination).as(:object).with(class_name: 'RequestedPoint') }
   it { is_expected.to define_attribute(:driver).as(:object).with(class_name: 'Driver') }
   it { is_expected.to define_attribute(:driver_id).as(:string) }


### PR DESCRIPTION
This adds `creator_id` and `creator_type` to the Ride model.