### PR TITLE
Reporting API

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -350,6 +350,15 @@ module Ioki
         ],
         path:        'rows',
         model_class: Ioki::Model::Operator::Reporting::ReportRow
+      ),
+      Endpoints::ShowSingular.new(
+        :reporting_report,
+        base_path:   nil,
+        path:        [
+          API_BASE_PATH, 'reporting', 'report', 'scopes', :scope,
+          'reports', :local_year, :name, :period_identifier, :version
+        ],
+        model_class: Ioki::Model::Operator::Reporting::Report
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -341,6 +341,15 @@ module Ioki
         base_path:   nil,
         path:        [API_BASE_PATH, 'reporting', 'report', 'scopes', :id, 'report_types', :name, 'summary'],
         model_class: Ioki::Model::Operator::Reporting::ReportTypeSummary
+      ),
+      Endpoints::Index.new(
+        :reporting_rows,
+        base_path:   [
+          API_BASE_PATH, 'reporting', 'report', 'scopes', :scope,
+          'reports', :local_year, :name, :period_identifier, :version
+        ],
+        path:        'rows',
+        model_class: Ioki::Model::Operator::Reporting::ReportRow
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -323,6 +323,12 @@ module Ioki
         :zone,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::Zone
+      ),
+      Endpoints::Index.new(
+        :reporting_scopes,
+        base_path:   [API_BASE_PATH, 'reporting', 'report'],
+        path:        'scopes',
+        model_class: Ioki::Model::Operator::Reporting::ReportScope
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -335,6 +335,12 @@ module Ioki
         base_path:   nil,
         path:        [API_BASE_PATH, 'reporting', 'report', 'scopes', :id, 'structure'],
         model_class: Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup
+      ),
+      Endpoints::ShowSingular.new(
+        :reporting_report_type_summary,
+        base_path:   nil,
+        path:        [API_BASE_PATH, 'reporting', 'report', 'scopes', :id, 'report_types', :name, 'summary'],
+        model_class: Ioki::Model::Operator::Reporting::ReportTypeSummary
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -329,6 +329,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'reporting', 'report'],
         path:        'scopes',
         model_class: Ioki::Model::Operator::Reporting::ReportScope
+      ),
+      Endpoints::ShowSingular.new(
+        :reporting_scope_structure,
+        base_path:   nil,
+        path:        [API_BASE_PATH, 'reporting', 'report', 'scopes', :id, 'structure'],
+        model_class: Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup
       )
     ].freeze
   end

--- a/lib/ioki/model.rb
+++ b/lib/ioki/model.rb
@@ -17,8 +17,8 @@ end.sort.each { |file| require file }
 Dir[File.join(__dir__, 'model', 'driver', '*')].reject do |filename|
   filename == File.join(__dir__, 'model', 'driver', 'base.rb')
 end.sort.each { |file| require file }
-Dir[File.join(__dir__, 'model', 'operator', '*')].reject do |filename|
-  filename == File.join(__dir__, 'model', 'operator', 'base.rb')
+Dir[File.join(__dir__, 'model', 'operator', '**', '*')].reject do |filename|
+  filename == File.join(__dir__, 'model', 'operator', 'base.rb') || File.directory?(filename)
 end.sort.each { |file| require file }
 Dir[File.join(__dir__, 'model', 'webhooks', '*')].reject do |filename|
   filename == File.join(__dir__, 'model', 'webhooks', 'base.rb')

--- a/lib/ioki/model/operator/reporting/report.rb
+++ b/lib/ioki/model/operator/reporting/report.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class Report < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :scope,
+                    on:   :read,
+                    type: :string
+
+          attribute :local_year,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :period_type,
+                    on:   :read,
+                    type: :string
+
+          attribute :period_identifier,
+                    on:   :read,
+                    type: :string
+
+          attribute :report_version,
+                    on:   :read,
+                    type: :integer
+
+          attribute :product_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :operator_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :starts_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :ends_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :timezone_identifier,
+                    on:   :read,
+                    type: :string
+
+          attribute :column_identifiers,
+                    on:   :read,
+                    type: :array
+
+          attribute :row_schema,
+                    on:   :read,
+                    type: :object
+
+          attribute :processing_state,
+                    on:   :read,
+                    type: :string
+
+          attribute :visible_while_draft,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :created_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :updated_at,
+                    on:   :read,
+                    type: :date_time
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_row.rb
+++ b/lib/ioki/model/operator/reporting/report_row.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportRow < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :data,
+                    on:   :read,
+                    type: :array
+
+          attribute :created_at,
+                    on:   :read,
+                    type: :date_time
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_scope.rb
+++ b/lib/ioki/model/operator/reporting/report_scope.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportScope < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_structure/divider.rb
+++ b/lib/ioki/model/operator/reporting/report_structure/divider.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        module ReportStructure
+          class Divider < Base
+            attribute :type,
+                      on:   :read,
+                      type: :string
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_structure/item.rb
+++ b/lib/ioki/model/operator/reporting/report_structure/item.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        module ReportStructure
+          class Item < Base
+            attribute :type,
+                      on:   :read,
+                      type: :string
+
+            attribute :name,
+                      on:   :read,
+                      type: :string
+
+            attribute :label,
+                      on:   :read,
+                      type: :string
+
+            attribute :description,
+                      on:   :read,
+                      type: :string
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_structure/item_group.rb
+++ b/lib/ioki/model/operator/reporting/report_structure/item_group.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        module ReportStructure
+          class ItemGroup < Base
+            attribute :type,
+                      on:   :read,
+                      type: :string
+
+            attribute :name,
+                      on:   :read,
+                      type: :string
+
+            attribute :label,
+                      on:   :read,
+                      type: :string
+
+            attribute :description,
+                      on:   :read,
+                      type: :string
+
+            attribute :items,
+                      on:         :read,
+                      type:       :array,
+                      class_name: ['Item', 'ItemGroup', 'Divider']
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_type.rb
+++ b/lib/ioki/model/operator/reporting/report_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportType < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :local_year,
+                    on:   :read,
+                    type: :string
+
+          attribute :period_identifier,
+                    on:   :read,
+                    type: :string
+
+          attribute :versions,
+                    on:   :read,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_type_summary.rb
+++ b/lib/ioki/model/operator/reporting/report_type_summary.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportTypeSummary < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :scope,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :report_types,
+                    on:         :read,
+                    type:       :array,
+                    class_name: 'ReportType'
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -1009,4 +1009,41 @@ RSpec.describe Ioki::Model::Base do
       end
     end
   end
+
+  context 'with different object types in array' do
+    let(:example_class) { Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup }
+    let(:attributes) do
+      {
+        items: [
+          {
+            'name'  => 'one',
+            'label' => 'One',
+            'type'  => 'reporting/report_structure/item'
+          },
+          {
+            'name'  => 'two',
+            'label' => 'Two',
+            'type'  => 'reporting/report_structure/item_group'
+          }
+        ]
+      }
+    end
+
+    it 'parses different objects in array' do
+      expect(model.data[:items]).to eq(
+        [
+          Ioki::Model::Operator::Reporting::ReportStructure::Item.new(
+            name:  'one',
+            label: 'One',
+            type:  'reporting/report_structure/item'
+          ),
+          Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup.new(
+            name:  'two',
+            label: 'Two',
+            type:  'reporting/report_structure/item_group'
+          )
+        ]
+      )
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1669,4 +1669,17 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Reporting::ReportTypeSummary)
     end
   end
+
+  describe '#reporting_rows' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s)
+          .to eq('operator/reporting/report/scopes/myscope/reports/myyear/myname/myperiod/myversion/rows')
+        result_with_index_data
+      end
+
+      expect(operator_client.reporting_rows('myscope', 'myyear', 'myname', 'myperiod', 'myversion', options))
+        .to all(be_a(Ioki::Model::Operator::Reporting::ReportRow))
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1645,4 +1645,16 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::Reporting::ReportScope))
     end
   end
+
+  describe '#reporting_scope_structure(scope_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/reporting/report/scopes/0815/structure')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.reporting_scope_structure('0815', options))
+        .to be_a(Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1682,4 +1682,17 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::Reporting::ReportRow))
     end
   end
+
+  describe '#reporting_report(scope, local_year, name, period_identifier, version)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s)
+          .to eq('operator/reporting/report/scopes/myscope/reports/myyear/myname/myperiod/myversion')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.reporting_report('myscope', 'myyear', 'myname', 'myperiod', 'myversion', options))
+        .to be_a(Ioki::Model::Operator::Reporting::Report)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1657,4 +1657,16 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Reporting::ReportStructure::ItemGroup)
     end
   end
+
+  describe '#reporting_report_type_summary(scope, local_year, name, period_identifier, version)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/reporting/report/scopes/0815/report_types/a-name/summary')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.reporting_report_type_summary('0815', 'a-name', options))
+        .to be_a(Ioki::Model::Operator::Reporting::ReportTypeSummary)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1633,4 +1633,16 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Area)
     end
   end
+
+  describe '#reporting_scopes' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/reporting/report/scopes')
+        result_with_index_data
+      end
+
+      expect(operator_client.reporting_scopes(options))
+        .to all(be_a(Ioki::Model::Operator::Reporting::ReportScope))
+    end
+  end
 end


### PR DESCRIPTION
This adds the basics of the reporting API.

It also improves ioki-ruby to allow parsing different types in an array. Untill now, only one type was supported. Instead of looking only at `class_name` of the attribute definition, we now also check if we have a `type` within the object in the array - if we have, we use that to create a Ruby class.

The following thus creates different classes within the array:

```ruby
[
  { type: 'car' },
  { type: 'bicycle' }
]

# results in
[
  Car.new(..),
  Bicycle.new(..)
]
```