### PR TITLE
Operator Api | Add `vehicle_positions` to `Ride` model

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -216,6 +216,11 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :vehicle_positions,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'VehiclePosition'
+
         attribute :vehicle_reached_dropoff,
                   on:   :read,
                   type: :boolean

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:valid_for_passenger_until).as(:date_time) }
   it { is_expected.to define_attribute(:vehicle).as(:object).with(class_name: 'Vehicle') }
   it { is_expected.to define_attribute(:vehicle_id).as(:string) }
+  it { is_expected.to define_attribute(:vehicle_positions).as(:array).with(class_name: 'VehiclePosition') }
   it { is_expected.to define_attribute(:vehicle_reached_dropoff).as(:boolean) }
   it { is_expected.to define_attribute(:vehicle_reached_pickup).as(:boolean) }
 end


### PR DESCRIPTION
This adds the attribute `vehicle_positions` to the `Ride` model.