### PR TITLE
Rename RematchingAttempt#auto_finish_empty_task_list

### DIFF
--- a/lib/ioki/model/operator/rematching_attempt.rb
+++ b/lib/ioki/model/operator/rematching_attempt.rb
@@ -20,7 +20,7 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
-        attribute :auto_cancel_empty_task_list,
+        attribute :auto_finish_empty_task_list,
                   on:             [:create, :read],
                   omit_if_nil_on: [:create],
                   type:           :boolean

--- a/spec/ioki/model/operator/rematching_attempt_spec.rb
+++ b/spec/ioki/model/operator/rematching_attempt_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Ioki::Model::Operator::RematchingAttempt do
   it { is_expected.to define_attribute(:type).as(:string) }
   it { is_expected.to define_attribute(:created_at).as(:date_time) }
   it { is_expected.to define_attribute(:updated_at).as(:date_time) }
-  it { is_expected.to define_attribute(:auto_cancel_empty_task_list).as(:boolean) }
+  it { is_expected.to define_attribute(:auto_finish_empty_task_list).as(:boolean) }
   it { is_expected.to define_attribute(:auto_cancel_failed_rematchings).as(:boolean) }
   it { is_expected.to define_attribute(:finished_at).as(:date_time) }
   it { is_expected.to define_attribute(:preserve_negotiated_times).as(:boolean) }


### PR DESCRIPTION
It was previously #auto_cancel_empty_task_list and now is #auto_finish_empty_task_list

This is technically a breaking change, however our server logs tell us that this is currently not in use. We can at this point in time simply update the name.