### PR TITLE
Remove report attributes from `ColumnDefinition`

### DIFF
--- a/lib/ioki/model/operator/reporting/report_column_definition.rb
+++ b/lib/ioki/model/operator/reporting/report_column_definition.rb
@@ -9,14 +9,6 @@ module Ioki
                     on:   :read,
                     type: :string
 
-          attribute :report_name,
-                    on:   :read,
-                    type: :string
-
-          attribute :report_version,
-                    on:   :read,
-                    type: :integer
-
           attribute :column_name,
                     on:   :read,
                     type: :string


### PR DESCRIPTION
Removes two attributes which have been removed from the API. They had just been added, so nobody was using them yet.