### PR TITLE
Operator Api | Add `passenger_note_to_driver`

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -161,6 +161,10 @@ module Ioki
         attribute :admins_can_set_arbitrary_driver_password,
                   type: :boolean,
                   on:   :read
+
+        attribute :passenger_note_to_driver,
+                  type: :boolean,
+                  on:   :read
       end
     end
   end

--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -122,6 +122,11 @@ module Ioki
                   type:       :array,
                   class_name: 'RidePassenger'
 
+        attribute :passenger_note_to_driver,
+                  on:   :read,
+                  type: :string
+
+
         attribute :payment_state,
                   on:   :read,
                   type: :string

--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -126,7 +126,6 @@ module Ioki
                   on:   :read,
                   type: :string
 
-
         attribute :payment_state,
                   on:   :read,
                   type: :string

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:origin).as(:object).with(class_name: 'RequestedPoint') }
   it { is_expected.to define_attribute(:passenger_can_be_called).as(:boolean) }
   it { is_expected.to define_attribute(:passengers).as(:array).with(class_name: 'RidePassenger') }
+  it { is_expected.to define_attribute(:passenger_note_to_driver).as(:string) }
   it { is_expected.to define_attribute(:payment_state).as(:string) }
   it { is_expected.to define_attribute(:pickup).as(:object).with(class_name: 'CalculatedPoint') }
   it { is_expected.to define_attribute(:pickup_task).as(:object).with(class_name: 'Task') }


### PR DESCRIPTION
This PR will add the attribute `passenger_note_to_driver` to the Ride model and to the Features model for the operator api.