### PR TITLE
Reporting | Add `visible_filter` to reporting column definitions

### DIFF
--- a/lib/ioki/model/operator/reporting/report_column_definition.rb
+++ b/lib/ioki/model/operator/reporting/report_column_definition.rb
@@ -29,6 +29,10 @@ module Ioki
                     on:   :read,
                     type: :boolean
 
+          attribute :visible_filter,
+                    on:   :read,
+                    type: :boolean
+
           attribute :visible_export,
                     on:   :read,
                     type: :boolean


### PR DESCRIPTION
Adds another visibility attribute to column definitions.