### PR TITLE
Reporting | Add filter flags

### DIFF
--- a/lib/ioki/model/operator/reporting/report.rb
+++ b/lib/ioki/model/operator/reporting/report.rb
@@ -78,6 +78,14 @@ module Ioki
                     type:       :array,
                     class_name: 'ReportColumnDefinition'
 
+          attribute :filterable_by_product,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :filterable_by_operator,
+                    on:   :read,
+                    type: :boolean
+
           attribute :processing_state,
                     on:   :read,
                     type: :string


### PR DESCRIPTION
This adds product and operator filter flags. That is, it indicates whether a report is filterable by product and/or operator.