### PR TITLE
Operator Api | Endpoints for `BlacklistedTravelCombination`

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -390,6 +390,11 @@ module Ioki
         :announcement,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::Announcement
+      ),
+      Endpoints.crud_endpoints(
+        :blacklisted_travel_combination,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::BlacklistedTravelCombination
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/blacklisted_travel_combination.rb
+++ b/lib/ioki/model/operator/blacklisted_travel_combination.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class BlacklistedTravelCombination < Base
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :destination,
+                  on:   :read,
+                  type: :string
+
+        attribute :destination_gid,
+                  on:             [:create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :has_recurrence_rules,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :name,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :origin,
+                  on:   :read,
+                  type: :string
+
+        attribute :origin_gid,
+                  on:             [:create, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :recurrence_rules,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :array,
+                  class_name:     'RecurrenceRule'
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2083,6 +2083,7 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  # rubocop:disable Layout/LineLength
   describe '#update_blacklisted_travel_combination(product_id, blacklisted_travel_combination_id, blacklisted_travel_combination)' do
     let(:blacklisted_travel_combination) { Ioki::Model::Operator::BlacklistedTravelCombination.new({ id: '4711' }) }
 
@@ -2097,6 +2098,7 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::BlacklistedTravelCombination)
     end
   end
+  # rubocop:enable Layout/LineLength
 
   describe '#delete_blacklisted_travel_combination(product_id, blacklisted_travel_combination_id)' do
     it 'calls request on the client with expected params' do

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2043,4 +2043,71 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Announcement)
     end
   end
+
+  describe '#blacklisted_travel_combinations(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/blacklisted_travel_combinations')
+        result_with_index_data
+      end
+
+      expect(operator_client.blacklisted_travel_combinations('0815', options))
+        .to all(be_a(Ioki::Model::Operator::BlacklistedTravelCombination))
+    end
+  end
+
+  describe '#blacklisted_travel_combination(product_id, blacklisted_travel_combination_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/blacklisted_travel_combinations/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.blacklisted_travel_combination('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::BlacklistedTravelCombination)
+    end
+  end
+
+  describe '#create_blacklisted_travel_combination(product_id, blacklisted_travel_combination)' do
+    let(:blacklisted_travel_combination) { Ioki::Model::Operator::BlacklistedTravelCombination.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/blacklisted_travel_combinations')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_blacklisted_travel_combination('0815', blacklisted_travel_combination, options))
+        .to be_a(Ioki::Model::Operator::BlacklistedTravelCombination)
+    end
+  end
+
+  describe '#update_blacklisted_travel_combination(product_id, blacklisted_travel_combination_id, blacklisted_travel_combination)' do
+    let(:blacklisted_travel_combination) { Ioki::Model::Operator::BlacklistedTravelCombination.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/blacklisted_travel_combinations/4711')
+        expect(params[:method]).to eq(:patch)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_blacklisted_travel_combination('0815', '4711', blacklisted_travel_combination, options))
+        .to be_a(Ioki::Model::Operator::BlacklistedTravelCombination)
+    end
+  end
+
+  describe '#delete_blacklisted_travel_combination(product_id, blacklisted_travel_combination_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/blacklisted_travel_combinations/4711')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_blacklisted_travel_combination('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::BlacklistedTravelCombination)
+    end
+  end
 end


### PR DESCRIPTION
This adds the endpoints for the resource `BlacklistedTravelCombination`.