### PR TITLE
Remove `StandardError` from retry mechanism

### DIFF
--- a/lib/ioki/retry.rb
+++ b/lib/ioki/retry.rb
@@ -21,13 +21,6 @@ module Ioki
 
         sleep(sleep_seconds)
         retry
-      rescue StandardError => e
-        retries -= 1
-
-        raise MaximumReached, "Gave up after #{max_retries} retries: #{e.message}" if retries <= 0
-
-        sleep(sleep_seconds)
-        retry
       end
     end
   end


### PR DESCRIPTION
The goal of the retry mechanism is to retry on network errors. If we encounter a `StandardError`, that is most likely not a network error and we should not retry it. It could be a bug in ioki-ruby, or incorrect input from the calling application. Either way, a retry is unlikely to fix the situation.

This also allows an application to raise its own exception within a block passed to ioki-ruby (e.g. in `auto_paginate`, useful if you want to abort the auto pagination). Before, this exception was caught by the retry mechanism and the request was retried. Now, it would not retry anymore.