### PR TITLE
Operator Api | Add `station` to `LineStop` model

### DIFF
--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -59,6 +59,11 @@ module Ioki
                   on:   [:read, :create],
                   type: :string
 
+        attribute :station,
+                  on:         [:read],
+                  type:       :object,
+                  class_name: 'Station'
+
         attribute :version,
                   on:   :read,
                   type: :integer


### PR DESCRIPTION
This PR introduces `station` to the `LineStop` model.