### PR TITLE
Change to be less strict when parsing type of sub-objects

### DIFF
--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -261,7 +261,7 @@ module Ioki
       def value_type(value)
         return value.attributes[:type] if value.respond_to?(:attributes)
 
-        value['type']
+        value['type'] || value[:type]
       end
 
       def parse_as_type(type, attribute, value)

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -732,6 +732,12 @@ RSpec.describe Ioki::Model::Base do
           expect(result).to be_a(Ioki::Model::Operator::Place)
           expect(result.type).to eq('place')
         end
+
+        it 'accepts symbolized keys' do
+          result = model.type_cast_attribute_value(:attr, { type: 'place' })
+          expect(result).to be_a(Ioki::Model::Operator::Place)
+          expect(result.type).to eq('place')
+        end
       end
     end
 


### PR DESCRIPTION
When we initialize a `Ioki::Model` with sub-objects, we read the `type` attribute to determine its type.

Usually we get it from an HTTP request and the hash keys (such as `type`) are stringified. However, if you initialize it on your own, you might use symbols as keys. Then the type of sub-objects is not parsed correctly.

The behavior broke in 7a4209d9