### PR TITLE
Operator Api | Allow updating `station_id` for `LineStop`

### DIFF
--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -56,7 +56,7 @@ module Ioki
                   type:           :boolean
 
         attribute :station_id,
-                  on:   [:read, :create],
+                  on:   [:read, :create, :update],
                   type: :string
 
         attribute :version,


### PR DESCRIPTION
This will add update access for the `station_id` attribute.