### PR TITLE
Operator Api | Add more attributes to `Ride`

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -55,6 +55,10 @@ module Ioki
                   type:       :object,
                   class_name: 'CancellationStatement'
 
+        attribute :cancelled_at,
+                  on:   :read,
+                  type: :date_time
+
         attribute :creator_id,
                   on:   :read,
                   type: :string
@@ -85,6 +89,10 @@ module Ioki
                   on:         :read,
                   type:       :object,
                   class_name: 'CalculatedPoint'
+
+        attribute :dropped_off_at,
+                  on:   :read,
+                  type: :date_time
 
         attribute :dropoff_task,
                   on:         :read,
@@ -129,6 +137,10 @@ module Ioki
         attribute :payment_state,
                   on:   :read,
                   type: :string
+
+        attribute :picked_up_at,
+                  on:   :read,
+                  type: :date_time
 
         attribute :pickup,
                   on:         :read,
@@ -216,6 +228,10 @@ module Ioki
                   type:       :object,
                   class_name: 'Vehicle'
 
+        attribute :vehicle_approached_pickup_at,
+                  on:   :read,
+                  type: :date_time
+
         attribute :vehicle_id,
                   on:   :read,
                   type: :string
@@ -229,9 +245,17 @@ module Ioki
                   on:   :read,
                   type: :boolean
 
+        attribute :vehicle_reached_dropoff_at,
+                  on:   :read,
+                  type: :date_time
+
         attribute :vehicle_reached_pickup,
                   on:   :read,
                   type: :boolean
+
+        attribute :vehicle_reached_pickup_at,
+                  on:   :read,
+                  type: :date_time
       end
     end
   end

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:cancellation_reason).as(:string) }
   it { is_expected.to define_attribute(:cancellation_reason_translated).as(:string) }
   it { is_expected.to define_attribute(:cancellation_statement).as(:object).with(class_name: 'CancellationStatement') }
+  it { is_expected.to define_attribute(:cancelled_at).as(:date_time) }
   it { is_expected.to define_attribute(:creator_id).as(:string) }
   it { is_expected.to define_attribute(:creator_type).as(:string) }
   it { is_expected.to define_attribute(:destination).as(:object).with(class_name: 'RequestedPoint') }
   it { is_expected.to define_attribute(:driver).as(:object).with(class_name: 'Driver') }
   it { is_expected.to define_attribute(:driver_id).as(:string) }
   it { is_expected.to define_attribute(:driver_can_be_called).as(:boolean) }
+  it { is_expected.to define_attribute(:dropped_off_at).as(:date_time) }
   it { is_expected.to define_attribute(:dropoff).as(:object).with(class_name: 'CalculatedPoint') }
   it { is_expected.to define_attribute(:dropoff_task).as(:object).with(class_name: 'Task') }
   it { is_expected.to define_attribute(:estimated_direct_distance).as(:integer) }
@@ -28,6 +30,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:passengers).as(:array).with(class_name: 'RidePassenger') }
   it { is_expected.to define_attribute(:passenger_note_to_driver).as(:string) }
   it { is_expected.to define_attribute(:payment_state).as(:string) }
+  it { is_expected.to define_attribute(:picked_up_at).as(:date_time) }
   it { is_expected.to define_attribute(:pickup).as(:object).with(class_name: 'CalculatedPoint') }
   it { is_expected.to define_attribute(:pickup_task).as(:object).with(class_name: 'Task') }
   it { is_expected.to define_attribute(:prebooked).as(:boolean) }
@@ -48,8 +51,11 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:valid_for_driver_until).as(:date_time) }
   it { is_expected.to define_attribute(:valid_for_passenger_until).as(:date_time) }
   it { is_expected.to define_attribute(:vehicle).as(:object).with(class_name: 'Vehicle') }
+  it { is_expected.to define_attribute(:vehicle_approached_pickup_at).as(:date_time) }
   it { is_expected.to define_attribute(:vehicle_id).as(:string) }
   it { is_expected.to define_attribute(:vehicle_positions).as(:array).with(class_name: 'VehiclePosition') }
   it { is_expected.to define_attribute(:vehicle_reached_dropoff).as(:boolean) }
+  it { is_expected.to define_attribute(:vehicle_reached_dropoff_at).as(:date_time) }
   it { is_expected.to define_attribute(:vehicle_reached_pickup).as(:boolean) }
+  it { is_expected.to define_attribute(:vehicle_reached_pickup_at).as(:date_time) }
 end


### PR DESCRIPTION
This adds more attributes to the `Ride` model:

```
- Ride Created at
- Ride Updated at
- Ride Cancelled at
- Vehicle Approached Pickup
- Reached Pickup at
- Picked up at
- Reached Dropoff at
- Dropped off at
```