### PR TITLE
Fix retry of `index` endpoints with `auto_paginate: true`

### DIFF
--- a/spec/ioki/client_spec.rb
+++ b/spec/ioki/client_spec.rb
@@ -120,7 +120,10 @@ RSpec.describe Ioki::Client do
       let(:response) { [500, {}, ''] }
 
       it 'maps this to the proper error and raises it' do
-        expect { client_response }.to raise_error(Ioki::Error::InternalServerError)
+        expect { client_response }.to raise_error(
+          an_instance_of(Ioki::Retry::MaximumReached)
+            .and(having_attributes(cause: an_instance_of(Ioki::Error::InternalServerError)))
+        )
       end
     end
 


### PR DESCRIPTION
When during an index auto_paginate a request failed, the retry mechanism started back at the first page. If a block was passed, that block was called again with all items of the previously already loaded pages. This caused blocks to be called multiple times and could result in duplicate data for the caller.

For example, if we have 3 pages with 2 items each, whereas each item is a growing integer. We expect the block to be called with the following values:

```
[0, 1, 2, 3, 4, 5]
```

When page 2 initially failed to load and then was retried, the blocks with the following values were called:

```
[0, 1, 0, 1, 2, 3, 4, 5]
```

The retry mechanism started back at the first page and called the block for every item of the first page again.

This fixes that issue by moving the retry mechanism directly to the HTTP request and ensures that only the request is retried and not any other logic around it.