### PR TITLE
fix: `Announcements#resource_id` omit nil values

### DIFF
--- a/lib/ioki/model/operator/announcement.rb
+++ b/lib/ioki/model/operator/announcement.rb
@@ -53,8 +53,9 @@ module Ioki
                   type: :array
 
         attribute :resource_id,
-                  on:   [:create, :read, :update],
-                  type: :string
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
       end
     end
   end


### PR DESCRIPTION
This PR will make sure that nil values will be omitted for `resource_id` on `create` and `update` actions.