### PR TITLE
Operator Api | Add attributes to `TaskList`

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -42,6 +42,11 @@ module Ioki
                   on:   :read,
                   type: :boolean
 
+        attribute :deactivations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Deactivation'
+
         attribute :end_location,
                   on:         :read,
                   type:       :object,
@@ -64,6 +69,10 @@ module Ioki
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],
                   type:           :string
+
+        attribute :matching_configuration_name,
+                  on:   :read,
+                  type: :string
 
         attribute :matching_rank,
                   on:   [:create, :read, :update],
@@ -144,6 +153,10 @@ module Ioki
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create],
                   type:           :string
+
+        attribute :line_name,
+                  on:   :read,
+                  type: :string
 
         attribute :version,
                   on:             [:read, :update],

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -62,11 +62,15 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:actual_starts_at).as(:date_time) }
     it { is_expected.to define_attribute(:ad_hoc_bookable).as(:boolean) }
     it { is_expected.to define_attribute(:deactivated).as(:boolean) }
+    it { is_expected.to define_attribute(:deactivations).as(:array).with(class_name: 'Deactivation') }
     it { is_expected.to define_attribute(:end_location).as(:object).with(class_name: %w[Place Station]) }
     it { is_expected.to define_attribute(:end_location_id).as(:string) }
     it { is_expected.to define_attribute(:end_location_type).as(:string) }
     it { is_expected.to define_attribute(:ends_at).as(:date_time) }
+    it { is_expected.to define_attribute(:line_id).as(:string) }
+    it { is_expected.to define_attribute(:line_name).as(:string) }
     it { is_expected.to define_attribute(:matching_configuration_id).as(:string) }
+    it { is_expected.to define_attribute(:matching_configuration_name).as(:string) }
     it { is_expected.to define_attribute(:matching_rank).as(:integer) }
     it { is_expected.to define_attribute(:num_prebooked_rides).as(:integer) }
     it { is_expected.to define_attribute(:paused).as(:boolean) }


### PR DESCRIPTION
This PR will add `deactivations`, `line_name` and `matching_configuration_name` to the `TaskList` model.