### PR TITLE
Operator API | Add `ReportPartitioninfo#estimated_row_count`

### DIFF
--- a/lib/ioki/model/operator/reporting/report_partition_info.rb
+++ b/lib/ioki/model/operator/reporting/report_partition_info.rb
@@ -13,6 +13,10 @@ module Ioki
                     on:   :read,
                     type: :string
 
+          attribute :estimated_row_count,
+                    on:   :read,
+                    type: :integer
+
           attribute :versions,
                     on:   :read,
                     type: :array


### PR DESCRIPTION
Adds a new attribute to `ReportPartitioninfo` in the operator API.