### PR TITLE
Operator Api | Add `driver_name` to `TaskList` model

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -158,6 +158,10 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :driver_name,
+                  on:   :read,
+                  type: :string
+
         attribute :version,
                   on:             [:read, :update],
                   omit_if_nil_on: [:update],

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:starts_at).as(:date_time) }
     it { is_expected.to define_attribute(:state).as(:string) }
     it { is_expected.to define_attribute(:vehicle_id).as(:string) }
+    it { is_expected.to define_attribute(:driver_name).as(:string) }
   end
 
   context 'when the start_location_type is place and the end_location_type is station' do


### PR DESCRIPTION
This adds the attribute `driver_name` to the `TaskList` model.