### PR TITLE
Operator Api | `Broadcast` endpoints

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -401,6 +401,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::RestrictedArea,
         except:      [:update]
+      ),
+      Endpoints.crud_endpoints(
+        :broadcast,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::Broadcast,
+        except:      [:delete, :show, :update]
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/broadcast.rb
+++ b/lib/ioki/model/operator/broadcast.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Broadcast < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :body,
+                  on:   [:create, :read],
+                  type: :string
+
+        attribute :admin_name,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2164,4 +2164,31 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::RestrictedArea)
     end
   end
+
+  describe '#broadcasts(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/broadcasts')
+        result_with_index_data
+      end
+
+      expect(operator_client.broadcasts('0815', options))
+        .to all(be_a(Ioki::Model::Operator::Broadcast))
+    end
+  end
+
+  describe '#create_broadcast(product_id, broadcast)' do
+    let(:broadcast) { Ioki::Model::Operator::Broadcast.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/broadcasts')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_broadcast('0815', broadcast, options))
+        .to be_a(Ioki::Model::Operator::Broadcast)
+    end
+  end
 end


### PR DESCRIPTION
This introduces the endpoints for the `broadcast` endpoints.