### PR TITLE
Operator Api | add `DriverReport` endpoints

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -418,6 +418,18 @@ module Ioki
         actions:     { 'acknowledge' => :patch },
         path:        [API_BASE_PATH, 'products', :id, 'driver_emergencies', :id],
         model_class: Ioki::Model::Operator::DriverEmergency
+      ),
+      Endpoints.crud_endpoints(
+        :driver_report,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::DriverReport,
+        except:      [:create, :delete, :update]
+      ),
+      Endpoints.custom_endpoints(
+        'driver_reports',
+        actions:     { 'acknowledge' => :patch },
+        path:        [API_BASE_PATH, 'products', :id, 'driver_reports', :id],
+        model_class: Ioki::Model::Operator::DriverReport
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/driver_report.rb
+++ b/lib/ioki/model/operator/driver_report.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class DriverReport < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :category,
+                  on:   :read,
+                  type: :string
+
+        attribute :driver_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :driver_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :driver_report_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :message,
+                  on:   :read,
+                  type: :string
+
+        attribute :acknowledged_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :acknowledger_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :acknowledger_name,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2216,4 +2216,41 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::DriverEmergency)
     end
   end
+
+  describe '#driver_reports(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_reports')
+        result_with_index_data
+      end
+
+      expect(operator_client.driver_reports('0815', options))
+        .to all(be_a(Ioki::Model::Operator::DriverReport))
+    end
+  end
+
+  describe '#driver_report(product_id, driver_report_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_reports/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.driver_report('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::DriverReport)
+    end
+  end
+
+  describe '#driver_reports_acknowledge(product_id, driver_report_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_reports/4711/acknowledge')
+        expect(params[:method]).to eq(:patch)
+        result_with_data
+      end
+
+      expect(operator_client.driver_reports_acknowledge('0815', '4711'))
+        .to be_a(Ioki::Model::Operator::DriverReport)
+    end
+  end
 end


### PR DESCRIPTION
This adds the `show`, `index` and `acknowledge` endpoints for the `DriverReport` resource for the operator api.