### PR TITLE
Passenger Api | Add `passenger_note_to_driver` to `Ride` model 

### DIFF
--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -47,6 +47,7 @@ module Ioki
         attribute :ticket, on: :read, type: :object, class_name: 'Ticket'
         attribute :offered_solutions, on: :read, type: :array, class_name: 'OfferedSolution'
         attribute :options, on: :create, type: :array, class_name: 'RideOption'
+        attribute :passenger_note_to_driver, type: :string, on: [:read, :create, :update]
         attribute :ride_series_id, on: :read, type: :string
       end
     end

--- a/lib/ioki/model/platform/product_features.rb
+++ b/lib/ioki/model/platform/product_features.rb
@@ -17,6 +17,7 @@ module Ioki
         attribute :station_search, type: :boolean, on: :read
         attribute :update_passengers_after_booking, type: :boolean, on: :read
         attribute :venues, type: :boolean, on: :read
+        attribute :passenger_note_to_driver, type: :boolean, on: :read
       end
     end
   end


### PR DESCRIPTION
This adds the attribute `passenger_note_to_driver` to the `Ride` model of the passenger API.

A bit suprisingly given the PR title it also adds it to the `ProductFeatures` model in the platform API. So far apparently this is only used for the schalter bootstrap deciding whether or not to show the textarea and in the integration spec in schalter to enable the feature for a test.