### PR TITLE
Operator Api | add `DriverMulticast` endpoints

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -435,6 +435,12 @@ module Ioki
         :venue,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::Venue
+      ),
+      Endpoints.crud_endpoints(
+        :driver_multicast,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::DriverMulticast,
+        except:      [:update, :delete]
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/driver_multicast.rb
+++ b/lib/ioki/model/operator/driver_multicast.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class DriverMulticast < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :body,
+                  on:   [:create, :read],
+                  type: :string
+
+        attribute :driver_ids,
+                  on:   :create,
+                  type: :array
+
+        attribute :receivers_count,
+                  on:   :read,
+                  type: :integer
+
+        attribute :sender_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :sender_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :sender_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :processed_at,
+                  type: :date_time,
+                  on:   :read
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2320,4 +2320,43 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Venue)
     end
   end
+
+  describe '#driver_multicasts(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_multicasts')
+        result_with_index_data
+      end
+
+      expect(operator_client.driver_multicasts('0815', options))
+        .to all(be_a(Ioki::Model::Operator::DriverMulticast))
+    end
+  end
+
+  describe '#driver_multicast(product_id, driver_multicast_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_multicasts/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.driver_multicast('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::DriverMulticast)
+    end
+  end
+
+  describe '#create_driver_multicast(product_id, driver_multicast)' do
+    let(:driver_multicast) { Ioki::Model::Operator::DriverMulticast.new({ id: '4711' }) }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/driver_multicasts')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_driver_multicast('0815', driver_multicast, options))
+        .to be_a(Ioki::Model::Operator::DriverMulticast)
+    end
+  end
 end


### PR DESCRIPTION
This adds the `DriverMulticast` model and the endpoints `index`, `show` and `create` for driver multicasts.