### PR TITLE
Remove obsolete `require`

### DIFF
--- a/lib/ioki/webhooks/event.rb
+++ b/lib/ioki/webhooks/event.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 module Ioki
   module Webhooks
     class Event


### PR DESCRIPTION
`OpenStruct` was removed in #509. The `require` was a leftover and still gives the impression that we use it, although we do not.

In newer Ruby versions it causes a warning that `ostruct` won't be part of the default gems in Ruby 3.5.