### PR TITLE
Operator Api | add `canceller` to `Ride` model

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -59,6 +59,10 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
+        attribute :canceller,
+                  on:   :read,
+                  type: :string
+
         attribute :creator_id,
                   on:   :read,
                   type: :string

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:cancellation_reason_translated).as(:string) }
   it { is_expected.to define_attribute(:cancellation_statement).as(:object).with(class_name: 'CancellationStatement') }
   it { is_expected.to define_attribute(:cancelled_at).as(:date_time) }
+  it { is_expected.to define_attribute(:canceller).as(:string) }
   it { is_expected.to define_attribute(:creator_id).as(:string) }
   it { is_expected.to define_attribute(:creator_type).as(:string) }
   it { is_expected.to define_attribute(:destination).as(:object).with(class_name: 'RequestedPoint') }


### PR DESCRIPTION
This PR adds the `canceller` to the `Ride` model.