### PR TITLE
Operator Api | Add `rating_line_items` to `Rating` model

### DIFF
--- a/lib/ioki/model/operator/rating.rb
+++ b/lib/ioki/model/operator/rating.rb
@@ -71,6 +71,11 @@ module Ioki
         attribute :waiting_time_rating,
                   on:   :read,
                   type: :integer
+
+        attribute :rating_line_items,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'RatingLineItem'
       end
     end
   end

--- a/lib/ioki/model/operator/rating_line_item.rb
+++ b/lib/ioki/model/operator/rating_line_item.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class RatingLineItem < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :criterion_slug,
+                  on:   :read,
+                  type: :string
+
+        attribute :value,
+                  on:   :read,
+                  type: :integer
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `rating_line_items` model and expose it in the `rating` model.