### PR TITLE
Operator Api | Add `last_connected_driver_id` to `TaskList`

### DIFF
--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -65,6 +65,10 @@ module Ioki
                   omit_if_nil_on: [:create, :update],
                   type:           :date_time
 
+        attribute :last_connected_driver_id,
+                  on:   :read,
+                  type: :string
+
         attribute :matching_configuration_id,
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],

--- a/spec/ioki/model/operator/task_list_spec.rb
+++ b/spec/ioki/model/operator/task_list_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Ioki::Model::Operator::TaskList do
     it { is_expected.to define_attribute(:state).as(:string) }
     it { is_expected.to define_attribute(:vehicle_id).as(:string) }
     it { is_expected.to define_attribute(:driver_name).as(:string) }
+    it { is_expected.to define_attribute(:last_connected_driver_id).as(:string) }
   end
 
   context 'when the start_location_type is place and the end_location_type is station' do


### PR DESCRIPTION
This adds the attribute `last_connected_driver_id` to the `TaskList` model.