### PR TITLE
Operator Api | Add `CustomFlag` model

### DIFF
--- a/lib/ioki/model/operator/custom_flag.rb
+++ b/lib/ioki/model/operator/custom_flag.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class CustomFlag < Base
+        attribute :name,
+                  on:   :read,
+                  type: :string
+
+        attribute :slug,
+                  on:   [:create, :read, :update],
+                  type: :string
+
+        attribute :value,
+                  on:   [:create, :read, :update],
+                  type: :boolean
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/product.rb
+++ b/lib/ioki/model/operator/product.rb
@@ -94,6 +94,10 @@ module Ioki
                   type:       :array,
                   class_name: 'Station'
 
+        attribute :has_custom_flags,
+                  on:   :read,
+                  type: :boolean
+
         attribute :matching_configurations,
                   on:         :read,
                   type:       :array,

--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -50,6 +50,11 @@ module Ioki
                   on:   [:read, :create, :update],
                   type: :string
 
+        attribute :custom_flags,
+                  on:         [:create, :read, :update],
+                  type:       :array,
+                  class_name: 'CustomFlag'
+
         attribute :deactivations,
                   on:         :read,
                   type:       :array,

--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -33,6 +33,11 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :custom_flags,
+                  on:         [:create, :read, :update],
+                  type:       :array,
+                  class_name: 'CustomFlag'
+
         attribute :default_resource_configuration,
                   on:         [:create, :read, :update],
                   type:       :object,

--- a/spec/ioki/model/operator/product_spec.rb
+++ b/spec/ioki/model/operator/product_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Ioki::Model::Operator::Product do
   it { is_expected.to define_attribute(:disable_station_markers).as(:boolean) }
   it { is_expected.to define_attribute(:features).as(:object).with(class_name: 'Features') }
   it { is_expected.to define_attribute(:fixed_stations).as(:array).with(class_name: 'Station') }
+  it { is_expected.to define_attribute(:has_custom_flags).as(:boolean) }
   it { is_expected.to define_attribute(:matching_configurations).as(:array).with(class_name: 'MatchingConfiguration') }
   it { is_expected.to define_attribute(:parking_time).as(:integer) }
   it { is_expected.to define_attribute(:prebookable).as(:boolean) }

--- a/spec/ioki/model/operator/vehicle_spec.rb
+++ b/spec/ioki/model/operator/vehicle_spec.rb
@@ -30,4 +30,5 @@ RSpec.describe Ioki::Model::Operator::Vehicle do
   it { is_expected.to define_attribute(:operator_id).as(:string) }
   it { is_expected.to define_attribute(:phone_number).as(:string) }
   it { is_expected.to define_attribute(:telemetry).as(:object).with(class_name: 'Telemetry') }
+  it { is_expected.to define_attribute(:custom_flags).as(:array).with(class_name: 'CustomFlag') }
 end


### PR DESCRIPTION
This adds the `CustomFlag` model for the operator api.