### PR TITLE
Operator Api | Add `last_serving_driver` to `Ride` model

### DIFF
--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -111,6 +111,11 @@ module Ioki
                   on:   :read,
                   type: :integer
 
+        attribute :last_serving_driver,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Driver'
+
         attribute :last_serving_driver_id,
                   on:   :read,
                   type: :string

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -61,4 +61,5 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:vehicle_reached_pickup).as(:boolean) }
   it { is_expected.to define_attribute(:vehicle_reached_pickup_at).as(:date_time) }
   it { is_expected.to define_attribute(:last_serving_driver_id).as(:string) }
+  it { is_expected.to define_attribute(:last_serving_driver).as(:object).with(class_name: 'Driver') }
 end


### PR DESCRIPTION
This adds the `last_serving_driver` object.