### PR TITLE
Operator API | Ioki suite navigation

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -446,6 +446,14 @@ module Ioki
         :public_transport_locations,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::PublicTransportLocation
+      ),
+      Endpoints::ShowSingular.new(
+        :ioki_suite_navigation,
+        base_path:   nil,
+        path:        [
+          API_BASE_PATH, 'services', 'ioki_suite_navigation'
+        ],
+        model_class: Ioki::Model::Operator::IokiSuiteNavigation::Menu
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/ioki_suite_navigation/divider.rb
+++ b/lib/ioki/model/operator/ioki_suite_navigation/divider.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module IokiSuiteNavigation
+        class Divider < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/ioki_suite_navigation/label.rb
+++ b/lib/ioki/model/operator/ioki_suite_navigation/label.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module IokiSuiteNavigation
+        class Label < Base
+          attribute :label,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/ioki_suite_navigation/menu.rb
+++ b/lib/ioki/model/operator/ioki_suite_navigation/menu.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module IokiSuiteNavigation
+        class Menu < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :slug,
+                    on:   :read,
+                    type: :string
+
+          attribute :icon,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :link,
+                    on:   :read,
+                    type: :string
+
+          attribute :menu_items,
+                    on:         :read,
+                    type:       :array,
+                    class_name: %w[Menu Label Divider]
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2371,4 +2371,16 @@ RSpec.describe Ioki::OperatorApi do
         .to all(be_a(Ioki::Model::Operator::PublicTransportLocation))
     end
   end
+
+  describe '#ioki_suite_navigation' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/services/ioki_suite_navigation')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.ioki_suite_navigation)
+        .to be_a(Ioki::Model::Operator::IokiSuiteNavigation::Menu)
+    end
+  end
 end


### PR DESCRIPTION
This adds the endpoint and models for the ioki suite navigation in the operator API.