### PR TITLE
Operator API | Bootstrap

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -7,6 +7,11 @@ module Ioki
   class OperatorApi
     API_BASE_PATH = 'operator'
     ENDPOINTS = [
+      Endpoints::ShowSingular.new(
+        :bootstrap,
+        base_path:   [API_BASE_PATH],
+        model_class: Ioki::Model::Operator::Bootstrap
+      ),
       Endpoints.crud_endpoints(
         :provider,
         base_path:   [API_BASE_PATH],

--- a/lib/ioki/model/operator/bootstrap.rb
+++ b/lib/ioki/model/operator/bootstrap.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Bootstrap < Base
+        attribute :type, on: :read, type: :string
+        attribute :valid_timezone_identifiers, type: :array, on: :read
+        attribute :valid_locales, type: :array, on: :read
+        attribute :supported_locales, type: :array, on: :read
+        attribute :admin, type: :object, on: :read, class_name: 'Admin'
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2383,4 +2383,16 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::IokiSuiteNavigation::Menu)
     end
   end
+
+  describe '#bootstrap' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/bootstrap')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.bootstrap)
+        .to be_a(Ioki::Model::Operator::Bootstrap)
+    end
+  end
 end


### PR DESCRIPTION
This adds the `bootstrap` endpoint to the operator API.