### PR TITLE
Operator API | Update account settings

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -459,6 +459,12 @@ module Ioki
           API_BASE_PATH, 'services', 'ioki_suite_navigation'
         ],
         model_class: Ioki::Model::Operator::IokiSuiteNavigation::Menu
+      ),
+      Endpoints::UpdateSingular.new(
+        :settings,
+        base_path:            [API_BASE_PATH, 'account'],
+        model_class:          Ioki::Model::Operator::Admin,
+        outgoing_model_class: Ioki::Model::Operator::Account::Settings
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/account/settings.rb
+++ b/lib/ioki/model/operator/account/settings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Account
+        class Settings < Base
+          attribute :first_name,
+                    on:   :update,
+                    type: :string
+
+          attribute :last_name,
+                    on:   :update,
+                    type: :string
+
+          attribute :locale,
+                    on:   :update,
+                    type: :string
+
+          attribute :timezone_identifier,
+                    on:   :update,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2395,4 +2395,18 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Bootstrap)
     end
   end
+
+  describe '#update_settings' do
+    let(:account_settings) { Ioki::Model::Operator::Account::Settings.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/account/settings')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.update_settings(account_settings))
+        .to be_a(Ioki::Model::Operator::Admin)
+    end
+  end
 end


### PR DESCRIPTION
Adds updating of account settings to the operator API.

This allows the current user to update their name, language and timezone.