### PR TITLE
Passenger API | Ticketing payment method types

### DIFF
--- a/lib/ioki/model/passenger/provider.rb
+++ b/lib/ioki/model/passenger/provider.rb
@@ -30,6 +30,7 @@ module Ioki
         attribute :stripe_account_id, on: :read, type: :string
         attribute :stripe_payment_method_types, on: :read, type: :array
         attribute :tip_payment_method_types, on: :read, type: :array
+        attribute :ticketing_payment_method_types, on: :read, type: :array
         attribute :version, on: :read, type: :integer
       end
     end


### PR DESCRIPTION
Adds a missing accessor for the payment method types used in ticketing to the passenger API.