### PR TITLE
Operator Api | Add `custom_flag_names` attribute to `Product` model

### DIFF
--- a/lib/ioki/model/operator/product.rb
+++ b/lib/ioki/model/operator/product.rb
@@ -55,6 +55,10 @@ module Ioki
                   type:       :object,
                   class_name: 'BoundingBox'
 
+        attribute :custom_flag_names,
+                  on:   :read,
+                  type: :array
+
         attribute :default_end_place_id,
                   on:   :read,
                   type: :string

--- a/spec/ioki/model/operator/product_spec.rb
+++ b/spec/ioki/model/operator/product_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Ioki::Model::Operator::Product do
   it { is_expected.to define_attribute(:service_time_info).as(:string) }
   it { is_expected.to define_attribute(:state).as(:string) }
   it { is_expected.to define_attribute(:timezone).as(:object).with(class_name: 'Timezone') }
+  it { is_expected.to define_attribute(:custom_flag_names).as(:array) }
 
   it {
     is_expected.to define_attribute(:translated_ride_cancellation_reasons).as(:array)


### PR DESCRIPTION
This adds `custom_flag_names` to the Product model.