### PR TITLE
Operator Api | Add `approach` to `Station` model

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -24,6 +24,10 @@ module Ioki
                   on:   :read,
                   type: :boolean
 
+        attribute :approach,
+                  on:   [:read, :create, :update],
+                  type: :string
+
         attribute :area,
                   on:         :read,
                   type:       :object,


### PR DESCRIPTION
This adds `approach` to the `Station` model for the operator api.