### PR TITLE
Passenger API | Add missing `paypal_secure_element`

### DIFF
--- a/lib/ioki/model/passenger/booking.rb
+++ b/lib/ioki/model/passenger/booking.rb
@@ -39,6 +39,8 @@ module Ioki
                   class_name:     'PaymentMethod',
                   unvalidated:    true,
                   omit_if_nil_on: :create
+
+        attribute :paypal_secure_element, type: :string, on: :create, omit_if_nil_on: :create
       end
     end
   end


### PR DESCRIPTION
When booking a ride, adds the `paypal_secure_element` attribute.