### PR TITLE
Operator Api | Add `RatingCriterion`

### DIFF
--- a/lib/ioki/apis/endpoints/endpoints.rb
+++ b/lib/ioki/apis/endpoints/endpoints.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/inflector'
+
 require_relative 'endpoint'
 require_relative 'create'
 require_relative 'show'
@@ -8,6 +10,10 @@ require_relative 'index'
 require_relative 'update'
 require_relative 'update_singular'
 require_relative 'delete'
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular 'rating_criterion', 'rating_criteria'
+end
 
 module Ioki
   module Endpoints

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -503,12 +503,7 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id],
         paths:       { show: 'rating_criteria' },
         model_class: Ioki::Model::Operator::RatingCriterion,
-        except:      [:index, :create, :update, :delete]
-      ),
-      Endpoints::Index.new(
-        :rating_criteria,
-        base_path:   [API_BASE_PATH, 'providers', :id],
-        model_class: Ioki::Model::Operator::RatingCriterion
+        only:        [:show, :index]
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -496,13 +496,6 @@ module Ioki
         :rating_criterion,
         base_path:   [API_BASE_PATH, 'providers', :id],
         model_class: Ioki::Model::Operator::RatingCriterion,
-        except:      [:create, :update, :delete]
-      ),
-      Endpoints.crud_endpoints(
-        :rating_criterion,
-        base_path:   [API_BASE_PATH, 'providers', :id],
-        paths:       { show: 'rating_criteria' },
-        model_class: Ioki::Model::Operator::RatingCriterion,
         only:        [:show, :index]
       )
     ].freeze

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -491,6 +491,24 @@ module Ioki
         path:                 'submissions',
         model_class:          Ioki::Model::Operator::Vehicle,
         outgoing_model_class: Ioki::Model::Operator::UploadSubmission
+      ),
+      Endpoints.crud_endpoints(
+        :rating_criterion,
+        base_path:   [API_BASE_PATH, 'providers', :id],
+        model_class: Ioki::Model::Operator::RatingCriterion,
+        except:      [:create, :update, :delete]
+      ),
+      Endpoints.crud_endpoints(
+        :rating_criterion,
+        base_path:   [API_BASE_PATH, 'providers', :id],
+        paths:       { show: 'rating_criteria' },
+        model_class: Ioki::Model::Operator::RatingCriterion,
+        except:      [:index, :create, :update, :delete]
+      ),
+      Endpoints::Index.new(
+        :rating_criteria,
+        base_path:   [API_BASE_PATH, 'providers', :id],
+        model_class: Ioki::Model::Operator::RatingCriterion
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/rating_criterion.rb
+++ b/lib/ioki/model/operator/rating_criterion.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class RatingCriterion < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :slug,
+                  on:   :read,
+                  type: :string
+
+        attribute :default,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :localized_name_translations,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'MultilanguageString'
+
+        attribute :localized_description_translations,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'MultilanguageString'
+      end
+    end
+  end
+end

--- a/spec/ioki/endpoints_spec.rb
+++ b/spec/ioki/endpoints_spec.rb
@@ -80,4 +80,14 @@ RSpec.describe Ioki::Endpoints do
       end
     end
   end
+
+  describe 'Custom inflections' do
+    it 'pluralizes "rating_criterion" correctly' do
+      expect('rating_criterion'.pluralize).to eq('rating_criteria')
+    end
+
+    it 'uses the singular correctly' do
+      expect('rating_criteria'.singularize).to eq('rating_criterion')
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2469,4 +2469,28 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::Station)
     end
   end
+
+  describe '#rating_criteria(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/rating_criteria')
+        result_with_index_data
+      end
+
+      expect(operator_client.rating_criteria('0815', options))
+        .to all(be_a(Ioki::Model::Operator::RatingCriterion))
+    end
+  end
+
+  describe '#rating_criterion(product_id, rating_criterion_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/rating_criteria/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.rating_criterion('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::RatingCriterion)
+    end
+  end
 end


### PR DESCRIPTION
This adds the endpoints for `RatingCriterion` and the corresponding model.