### PR TITLE
Operator Api | Add `driver_notifications` to `DriverMulticast`

### DIFF
--- a/lib/ioki/model/operator/driver_multicast.rb
+++ b/lib/ioki/model/operator/driver_multicast.rb
@@ -28,6 +28,11 @@ module Ioki
                   on:   :create,
                   type: :array
 
+        attribute :driver_notifications,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Ioki::Model::Operator::DriverNotification'
+
         attribute :receivers_count,
                   on:   :read,
                   type: :integer

--- a/lib/ioki/model/operator/driver_notification.rb
+++ b/lib/ioki/model/operator/driver_notification.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class DriverNotification < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :receiver_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :receiver_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :read_at,
+                  on:   :read,
+                  type: :date_time
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the attribute `driver_notifcations` to the `DriverMulticast` model.