### PR TITLE
Operator API | Add unread notifications

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -497,6 +497,14 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id],
         model_class: Ioki::Model::Operator::RatingCriterion,
         only:        [:show, :index]
+      ),
+      Endpoints::ShowSingular.new(
+        :admin_notifications_unread_count,
+        base_path:   nil,
+        path:        [
+          API_BASE_PATH, 'admin', 'admin_notifications', 'unread_count'
+        ],
+        model_class: Ioki::Model::Operator::AdminNotification::UnreadCount
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/admin_notification/unread_count.rb
+++ b/lib/ioki/model/operator/admin_notification/unread_count.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module AdminNotification
+        class UnreadCount < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :unread_count,
+                    on:   :read,
+                    type: :integer
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2493,4 +2493,16 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::RatingCriterion)
     end
   end
+
+  describe '#admin_notifications_unread_count' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/admin/admin_notifications/unread_count')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.admin_notifications_unread_count)
+        .to be_a(Ioki::Model::Operator::AdminNotification::UnreadCount)
+    end
+  end
 end


### PR DESCRIPTION
Adds an endpoint to fetch the count of unread notifications.