### PR TITLE
Operator API | Add consentables endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -505,6 +505,11 @@ module Ioki
           API_BASE_PATH, 'admin', 'admin_notifications', 'unread_count'
         ],
         model_class: Ioki::Model::Operator::AdminNotification::UnreadCount
+      ),
+      Endpoints::Index.new(
+        :consentables,
+        base_path:   [API_BASE_PATH, 'admin'],
+        model_class: Ioki::Model::Operator::Consentable
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/consentable.rb
+++ b/lib/ioki/model/operator/consentable.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class Consentable < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :slug,
+                  on:   :read,
+                  type: :string
+
+        attribute :changed_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :must_accept,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :required_pre_registration,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :website_url,
+                  on:   :read,
+                  type: :string
+
+        attribute :translated_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :translated_description,
+                  on:   :read,
+                  type: :string
+
+        attribute :translated_link_text,
+                  on:   :read,
+                  type: :string
+
+        attribute :translated_agree_phrase,
+                  on:   :read,
+                  type: :string
+
+        attribute :translated_disagree_phrase,
+                  on:   :read,
+                  type: :string
+
+        attribute :accepted_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :rejected_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :accepted,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :rejected,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :awaiting_decision,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :mandatory_but_not_accepted,
+                  on:   :read,
+                  type: :boolean
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2505,4 +2505,16 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::AdminNotification::UnreadCount)
     end
   end
+
+  describe '#consentables' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/admin/consentables')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.consentables)
+        .to all be_a(Ioki::Model::Operator::Consentable)
+    end
+  end
 end


### PR DESCRIPTION
Adds an endpoint to fetch consentables for the current admin.