### PR TITLE
Operator API | Revert reporting info deprecation

### DIFF
--- a/lib/ioki/model/operator/reporting/report_partition_info.rb
+++ b/lib/ioki/model/operator/reporting/report_partition_info.rb
@@ -18,9 +18,8 @@ module Ioki
                     type: :integer
 
           attribute :versions,
-                    on:         :read,
-                    type:       :array,
-                    deprecated: true
+                    on:   :read,
+                    type: :array
 
           attribute :variants,
                     on:         :read,


### PR DESCRIPTION
The deprecation causes many issues I haven't found the root cause yet. Let's remove it for now, until we can get rid of the attribute alltogether :slightly_smiling_face: 