### PR TITLE
Operator Api | Add `avatar` attribute to `Station` model

### DIFF
--- a/lib/ioki/model/operator/station.rb
+++ b/lib/ioki/model/operator/station.rb
@@ -38,6 +38,11 @@ module Ioki
                   type:           :string,
                   omit_if_nil_on: [:create, :update]
 
+        attribute :avatar,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'ImageUpload'
+
         attribute :boarding_time,
                   on:   [:read, :create, :update],
                   type: :integer


### PR DESCRIPTION
This adds the avatar/image to the `Station` model.