### PR TITLE
Add FleetState endpoint to Platform API

### DIFF
--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -296,7 +296,7 @@ module Ioki
       ),
       Endpoints::ShowSingular.new(
         :fleet_state,
-        base_path:   [API_BASE_PATH],
+        base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Platform::FleetState
       )
     ].freeze

--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -296,7 +296,7 @@ module Ioki
       ),
       Endpoints::ShowSingular.new(
         :fleet_state,
-        base_path:   [API_BASE_PATH, 'products', :id],
+        base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Platform::FleetState
       )
     ].freeze

--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -298,7 +298,7 @@ module Ioki
         :fleet_state,
         base_path:   [API_BASE_PATH],
         model_class: Ioki::Model::Platform::FleetState
-      ),
+      )
     ].freeze
   end
 end

--- a/lib/ioki/apis/platform_api.rb
+++ b/lib/ioki/apis/platform_api.rb
@@ -293,7 +293,12 @@ module Ioki
         :intermodal_area,
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Platform::Area
-      )
+      ),
+      Endpoints::ShowSingular.new(
+        :fleet_state,
+        base_path:   [API_BASE_PATH],
+        model_class: Ioki::Model::Platform::FleetState
+      ),
     ].freeze
   end
 end

--- a/lib/ioki/model/platform/fleet_state.rb
+++ b/lib/ioki/model/platform/fleet_state.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class FleetState < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :limit_reached,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :vehicles,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Vehicle'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/telemetry.rb
+++ b/lib/ioki/model/platform/telemetry.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Platform
+      class Telemetry < Base
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :altitude,
+                  on:   :read,
+                  type: :float
+
+        attribute :altitude_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :altitude_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :battery_level,
+                  on:   :read,
+                  type: :float
+
+        attribute :battery_level_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :battery_level_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :charging_state,
+                  on:   :read,
+                  type: :string
+
+        attribute :charging_state_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :charging_state_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :door_state,
+                  on:   :read,
+                  type: :string
+
+        attribute :door_state_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :door_state_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :estimated_time_until_full_recharge,
+                  on:   :read,
+                  type: :float
+
+        attribute :estimated_time_until_full_recharge_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :estimated_time_until_full_recharge_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :heading,
+                  on:   :read,
+                  type: :float
+
+        attribute :heading_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :heading_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :lat,
+                  on:   :read,
+                  type: :float
+
+        attribute :lat_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :lat_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :lng,
+                  on:   :read,
+                  type: :float
+
+        attribute :lng_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :lng_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :mobileye_mission_state,
+                  on:   :read,
+                  type: :string
+
+        attribute :mobileye_mission_state_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :mobileye_mission_state_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :mobileye_sds_state,
+                  on:   :read,
+                  type: :string
+
+        attribute :mobileye_sds_state_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :mobileye_sds_state_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :people_count,
+                  on:   :read,
+                  type: :integer
+
+        attribute :people_count_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :people_count_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :remaining_distance,
+                  on:   :read,
+                  type: :float
+
+        attribute :remaining_distance_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :remaining_distance_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :speed,
+                  on:   :read,
+                  type: :float
+
+        attribute :speed_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :speed_synced_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :tires_pressure,
+                  on:   :read,
+                  type: :array
+
+        attribute :tires_pressure_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :tires_pressure_synced_at,
+                  on:   :read,
+                  type: :date_time
+      end
+    end
+  end
+end

--- a/lib/ioki/model/platform/vehicle.rb
+++ b/lib/ioki/model/platform/vehicle.rb
@@ -82,6 +82,11 @@ module Ioki
         attribute :version,
                   on:   [:read, :update],
                   type: :integer
+
+        attribute :telemetry,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Telemetry'
       end
     end
   end

--- a/spec/ioki/model/platform/telemetry_spec.rb
+++ b/spec/ioki/model/platform/telemetry_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Platform::Telemetry do
+  it { is_expected.to define_attribute(:id).as(:string) }
+  it { is_expected.to define_attribute(:altitude).as(:float) }
+  it { is_expected.to define_attribute(:altitude_source).as(:string) }
+  it { is_expected.to define_attribute(:altitude_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:battery_level).as(:float) }
+  it { is_expected.to define_attribute(:battery_level_source).as(:string) }
+  it { is_expected.to define_attribute(:battery_level_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:charging_state).as(:string) }
+  it { is_expected.to define_attribute(:charging_state_source).as(:string) }
+  it { is_expected.to define_attribute(:charging_state_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:door_state).as(:string) }
+  it { is_expected.to define_attribute(:door_state_source).as(:string) }
+  it { is_expected.to define_attribute(:door_state_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:estimated_time_until_full_recharge).as(:float) }
+  it { is_expected.to define_attribute(:estimated_time_until_full_recharge_source).as(:string) }
+  it { is_expected.to define_attribute(:estimated_time_until_full_recharge_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:heading).as(:float) }
+  it { is_expected.to define_attribute(:heading_source).as(:string) }
+  it { is_expected.to define_attribute(:heading_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:lat).as(:float) }
+  it { is_expected.to define_attribute(:lat_source).as(:string) }
+  it { is_expected.to define_attribute(:lat_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:lng).as(:float) }
+  it { is_expected.to define_attribute(:lng_source).as(:string) }
+  it { is_expected.to define_attribute(:lng_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:mobileye_mission_state).as(:string) }
+  it { is_expected.to define_attribute(:mobileye_mission_state_source).as(:string) }
+  it { is_expected.to define_attribute(:mobileye_mission_state_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:mobileye_sds_state).as(:string) }
+  it { is_expected.to define_attribute(:mobileye_sds_state_source).as(:string) }
+  it { is_expected.to define_attribute(:mobileye_sds_state_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:people_count).as(:integer) }
+  it { is_expected.to define_attribute(:people_count_source).as(:string) }
+  it { is_expected.to define_attribute(:people_count_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:remaining_distance).as(:float) }
+  it { is_expected.to define_attribute(:remaining_distance_source).as(:string) }
+  it { is_expected.to define_attribute(:remaining_distance_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:speed).as(:float) }
+  it { is_expected.to define_attribute(:speed_source).as(:string) }
+  it { is_expected.to define_attribute(:speed_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:tires_pressure).as(:array) }
+  it { is_expected.to define_attribute(:tires_pressure_source).as(:string) }
+  it { is_expected.to define_attribute(:tires_pressure_synced_at).as(:date_time) }
+end

--- a/spec/ioki/platform_api_spec.rb
+++ b/spec/ioki/platform_api_spec.rb
@@ -935,4 +935,15 @@ RSpec.describe Ioki::PlatformApi do
         .to be_a(Ioki::Model::Platform::Area)
     end
   end
+
+  describe '#fleet_state' do
+    it 'calls request on the client with expected params' do
+      expect(platform_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('platform/fleet_state')
+        [result_with_data, full_response]
+      end
+
+      expect(platform_client.fleet_state(options)).to be_a Ioki::Model::Platform::FleetState
+    end
+  end
 end


### PR DESCRIPTION
This is my first time making a PR for ioki-ruby, so please let me know if I missed anything critical.

We will need this endpoint for ioki Workflow, but it doesn't seem to exist in the client yet. So I'm adding it here. I copied all the changes from the Operator API, which already implements this endpoint.