### PR TITLE
Add seatbelt state to telemetry

### DIFF
--- a/lib/ioki/model/platform/telemetry.rb
+++ b/lib/ioki/model/platform/telemetry.rb
@@ -152,6 +152,10 @@ module Ioki
                   on:   :read,
                   type: :date_time
 
+        attribute :seatbelt_state,
+                  on:   :read,
+                  type: :string
+
         attribute :speed,
                   on:   :read,
                   type: :float

--- a/lib/ioki/model/platform/telemetry.rb
+++ b/lib/ioki/model/platform/telemetry.rb
@@ -156,6 +156,14 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :seatbelt_state_source,
+                  on:   :read,
+                  type: :string
+
+        attribute :seatbelt_state_synced_at,
+                  on:   :read,
+                  type: :date_time
+
         attribute :speed,
                   on:   :read,
                   type: :float

--- a/spec/ioki/model/platform/telemetry_spec.rb
+++ b/spec/ioki/model/platform/telemetry_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Ioki::Model::Platform::Telemetry do
   it { is_expected.to define_attribute(:remaining_distance_source).as(:string) }
   it { is_expected.to define_attribute(:remaining_distance_synced_at).as(:date_time) }
   it { is_expected.to define_attribute(:seatbelt_state).as(:string) }
+  it { is_expected.to define_attribute(:seatbelt_state_source).as(:string) }
+  it { is_expected.to define_attribute(:seatbelt_state_synced_at).as(:date_time) }
   it { is_expected.to define_attribute(:speed).as(:float) }
   it { is_expected.to define_attribute(:speed_source).as(:string) }
   it { is_expected.to define_attribute(:speed_synced_at).as(:date_time) }

--- a/spec/ioki/model/platform/telemetry_spec.rb
+++ b/spec/ioki/model/platform/telemetry_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Ioki::Model::Platform::Telemetry do
   it { is_expected.to define_attribute(:remaining_distance).as(:float) }
   it { is_expected.to define_attribute(:remaining_distance_source).as(:string) }
   it { is_expected.to define_attribute(:remaining_distance_synced_at).as(:date_time) }
+  it { is_expected.to define_attribute(:seatbelt_state).as(:string) }
   it { is_expected.to define_attribute(:speed).as(:float) }
   it { is_expected.to define_attribute(:speed_source).as(:string) }
   it { is_expected.to define_attribute(:speed_synced_at).as(:date_time) }


### PR DESCRIPTION
I noticed that the seatbelt state is missing in the telemetry model. It's present in the Platform API serializer for vehicle telemetry and also an attribute that we want to have in Workflow.