### PR TITLE
Operator API | Add `localized_reference_timestamp` for reporting

### DIFF
--- a/lib/ioki/model/operator/reporting/report.rb
+++ b/lib/ioki/model/operator/reporting/report.rb
@@ -29,6 +29,10 @@ module Ioki
                     on:   :read,
                     type: :string
 
+          attribute :localized_reference_timestamp,
+                    on:   :read,
+                    type: :string
+
           attribute :default_query_timeframe,
                     on:   :read,
                     type: :string

--- a/lib/ioki/model/operator/reporting/report_partition.rb
+++ b/lib/ioki/model/operator/reporting/report_partition.rb
@@ -33,6 +33,10 @@ module Ioki
                     on:   :read,
                     type: :string
 
+          attribute :localized_reference_timestamp,
+                    on:   :read,
+                    type: :string
+
           attribute :period_type,
                     on:   :read,
                     type: :string


### PR DESCRIPTION
Adds the `localized_reference_timestamp` to the models in the operator API.