### PR TITLE
Reporting | Booleans for `null` values in filters

### DIFF
--- a/lib/ioki/model/operator/reporting/report.rb
+++ b/lib/ioki/model/operator/reporting/report.rb
@@ -37,7 +37,15 @@ module Ioki
                     on:   :read,
                     type: :boolean
 
+          attribute :null_value_in_product_filter,
+                    on:   :read,
+                    type: :boolean
+
           attribute :filterable_by_operator,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :null_value_in_operator_filter,
                     on:   :read,
                     type: :boolean
 

--- a/lib/ioki/model/operator/reporting/report_partition.rb
+++ b/lib/ioki/model/operator/reporting/report_partition.rb
@@ -86,7 +86,15 @@ module Ioki
                     on:   :read,
                     type: :boolean
 
+          attribute :null_value_in_product_filter,
+                    on:   :read,
+                    type: :boolean
+
           attribute :filterable_by_operator,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :null_value_in_operator_filter,
                     on:   :read,
                     type: :boolean
 


### PR DESCRIPTION
Adds attributes which indicate whether a filter accepts `null` values.