### PR TITLE
Operator Api | Add more missing features to the `Features` model

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -22,6 +22,10 @@ module Ioki
                   type: :boolean,
                   on:   :read
 
+        attribute :supports_passenger_update_by_user,
+                  type: :boolean,
+                  on:   :read
+
         attribute :supports_passenger_cancellation_statement,
                   type: :boolean,
                   on:   :read
@@ -59,6 +63,10 @@ module Ioki
                   on:   :read
 
         attribute :supports_blacklisted_travel_combinations,
+                  type: :boolean,
+                  on:   :read
+
+        attribute :supports_gtfs_flex_feed,
                   type: :boolean,
                   on:   :read
 


### PR DESCRIPTION
Unfortunately, I missed two attributes for the features model. This will add the missing attributes.