### PR TITLE
Operator API | Geocoding

### DIFF
--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -31,7 +31,7 @@ module Ioki
           params: options[:params]
         )
 
-        return if parsed_response.nil?
+        return if parsed_response.nil? || model_class.nil?
 
         model_class
           .new(parsed_response['data'], nil, show_deprecation_warnings: false)

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -509,6 +509,12 @@ module Ioki
         :consentables,
         base_path:   [API_BASE_PATH, 'admin'],
         model_class: Ioki::Model::Operator::Consentable
+      ),
+      Endpoints::Create.new(
+        :geocoding_session,
+        base_path:   [API_BASE_PATH, 'geocoding'],
+        path:        'session',
+        model_class: Ioki::Model::Operator::GeocodingSession
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -521,6 +521,13 @@ module Ioki
         base_path:   [API_BASE_PATH, 'geocoding'],
         path:        'session',
         model_class: nil
+      ),
+      Endpoints::Create.new(
+        :geocoding_search,
+        base_path:            [API_BASE_PATH, 'geocoding', 'session', :id],
+        path:                 'search',
+        model_class:          Ioki::Model::Operator::GeocodingSearchResults,
+        outgoing_model_class: Ioki::Model::Operator::GeocodingSearch
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -515,6 +515,12 @@ module Ioki
         base_path:   [API_BASE_PATH, 'geocoding'],
         path:        'session',
         model_class: Ioki::Model::Operator::GeocodingSession
+      ),
+      Endpoints::Delete.new(
+        :geocoding_session,
+        base_path:   [API_BASE_PATH, 'geocoding'],
+        path:        'session',
+        model_class: nil
       )
     ].freeze
   end

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -528,6 +528,12 @@ module Ioki
         path:                 'search',
         model_class:          Ioki::Model::Operator::GeocodingSearchResults,
         outgoing_model_class: Ioki::Model::Operator::GeocodingSearch
+      ),
+      Endpoints::Create.new(
+        :geocoding_search_details,
+        base_path:   [API_BASE_PATH, 'geocoding', 'session', :id],
+        path:        'details',
+        model_class: Ioki::Model::Operator::GeocodingSearchDetails
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/geocoding_search.rb
+++ b/lib/ioki/model/operator/geocoding_search.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class GeocodingSearch < Base
+        attribute :query,
+                  on:   :create,
+                  type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/geocoding_search_details.rb
+++ b/lib/ioki/model/operator/geocoding_search_details.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class GeocodingSearchDetails < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :create,
+                  type: :string
+
+        attribute :vendor_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :location_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :formatted_address,
+                  on:   :read,
+                  type: :string
+
+        attribute :street_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :street_number,
+                  on:   :read,
+                  type: :string
+
+        attribute :postal_code,
+                  on:   :read,
+                  type: :string
+
+        attribute :city,
+                  on:   :read,
+                  type: :string
+
+        attribute :county,
+                  on:   :read,
+                  type: :string
+
+        attribute :country,
+                  on:   :read,
+                  type: :string
+
+        attribute :lat,
+                  on:   :read,
+                  type: :float
+
+        attribute :lng,
+                  on:   :read,
+                  type: :float
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/geocoding_search_result.rb
+++ b/lib/ioki/model/operator/geocoding_search_result.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class GeocodingSearchResult < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor,
+                  on:   :read,
+                  type: :string
+
+        attribute :formatted_address,
+                  on:   :read,
+                  type: :string
+
+        attribute :description,
+                  on:   :read,
+                  type: :string
+
+        attribute :location_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :lat,
+                  on:   :read,
+                  type: :float
+
+        attribute :lng,
+                  on:   :read,
+                  type: :float
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/geocoding_search_results.rb
+++ b/lib/ioki/model/operator/geocoding_search_results.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class GeocodingSearchResults < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :results,
+                  on:    :read,
+                  type:  :array,
+                  class: 'Ioki::Model::Operator::GeocodingSearchResult'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/geocoding_session.rb
+++ b/lib/ioki/model/operator/geocoding_session.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class GeocodingSession < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :valid_until,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :user_id,
+                  on:   :create,
+                  type: :string
+
+        attribute :product_id,
+                  on:   :create,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2546,4 +2546,17 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::GeocodingSession)
     end
   end
+
+  describe '#delete_geocoding_session(id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/geocoding/session/0815')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(operator_client.delete_geocoding_session('0815', options))
+        .to be_nil
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2559,4 +2559,19 @@ RSpec.describe Ioki::OperatorApi do
         .to be_nil
     end
   end
+
+  describe '#create_geocoding_search(id)' do
+    let(:geocoding_search) { Ioki::Model::Operator::GeocodingSearch.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/geocoding/session/0815/search')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_geocoding_search('0815', geocoding_search, options))
+        .to be_a(Ioki::Model::Operator::GeocodingSearchResults)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2574,4 +2574,19 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::GeocodingSearchResults)
     end
   end
+
+  describe '#create_geocoding_search_details(id)' do
+    let(:geocoding_search_details) { Ioki::Model::Operator::GeocodingSearchDetails.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/geocoding/session/0815/details')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_geocoding_search_details('0815', geocoding_search_details, options))
+        .to be_a(Ioki::Model::Operator::GeocodingSearchDetails)
+    end
+  end
 end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -2531,4 +2531,19 @@ RSpec.describe Ioki::OperatorApi do
         .to all be_a(Ioki::Model::Operator::Consentable)
     end
   end
+
+  describe '#create_geocoding_session()' do
+    let(:geocoding_session) { Ioki::Model::Operator::GeocodingSession.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/geocoding/session')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_geocoding_session(geocoding_session, options))
+        .to be_a(Ioki::Model::Operator::GeocodingSession)
+    end
+  end
 end


### PR DESCRIPTION
Adds endpoints for geocoding, which allows to search for stations and places in the same API request.