### PR TITLE
Operator Api | Add `batch_destroy` action for `Stations`

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -83,6 +83,12 @@ module Ioki
         path:        [API_BASE_PATH, 'products', :id, 'stations', :id],
         model_class: Ioki::Model::Operator::Station
       ),
+      Endpoints.custom_endpoints(
+        'stations',
+        actions:     { 'batch_destroy' => :delete },
+        path:        [API_BASE_PATH, 'products', :id, 'stations'],
+        model_class: nil
+      ),
       Endpoints::Index.new(
         :station_overview,
         base_path:   [API_BASE_PATH, 'products', :id, 'stations'],

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -434,6 +434,19 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#stations_batch_destroy(product_id)' do
+    let(:result_with_data) { nil }
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/stations/batch_destroy')
+        result_with_data
+      end
+
+      expect(operator_client.stations_batch_destroy('0815', options))
+        .to be_nil
+    end
+  end
+
   describe '#station_overview(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
This add the `batch_destroy` action for stations.