### PR TITLE
Operator API | Fix attribute option

### DIFF
--- a/lib/ioki/model/operator/geocoding_search_results.rb
+++ b/lib/ioki/model/operator/geocoding_search_results.rb
@@ -9,9 +9,9 @@ module Ioki
                   type: :string
 
         attribute :results,
-                  on:    :read,
-                  type:  :array,
-                  class: 'Ioki::Model::Operator::GeocodingSearchResult'
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Ioki::Model::Operator::GeocodingSearchResult'
       end
     end
   end


### PR DESCRIPTION
Fixes the attribute option to correctly parse the objects within the array. It is called `class_name`, not just `class`.