### PR TITLE
Operator Api: Add missing attribute to Features model

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -26,6 +26,10 @@ module Ioki
                   type: :boolean,
                   on:   :read
 
+        attribute :supports_passenger_update_by_driver,
+                  type: :boolean,
+                  on:   :read
+
         attribute :supports_passenger_cancellation_statement,
                   type: :boolean,
                   on:   :read


### PR DESCRIPTION
This adds the `supports_passenger_update_by_driver` attribute to the Features model.