### PR TITLE
Operator API | Custom tags for task lists

### DIFF
--- a/lib/ioki/model/operator/custom_tag.rb
+++ b/lib/ioki/model/operator/custom_tag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class CustomTag < Base
+        def self.schema_path
+          'operator_api--v20210101--custom_tag_schema'
+        end
+
+        attribute :label,
+                  on:   [:create, :read, :update],
+                  type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/task_list.rb
+++ b/lib/ioki/model/operator/task_list.rb
@@ -166,6 +166,11 @@ module Ioki
                   on:   :read,
                   type: :string
 
+        attribute :custom_tags,
+                  on:         [:create, :read, :update],
+                  type:       :array,
+                  class_name: Ioki::Model::Operator::CustomTag
+
         attribute :version,
                   on:             [:read, :update],
                   omit_if_nil_on: [:update],


### PR DESCRIPTION
Adds `custom_tags` to task lists in the operator API.