### PR TITLE
Operator | Fix access for `StationBatch` and `TaskListBatch`

### DIFF
--- a/lib/ioki/model/operator/station_batch.rb
+++ b/lib/ioki/model/operator/station_batch.rb
@@ -9,7 +9,7 @@ module Ioki
         end
 
         attribute :station_ids,
-                  on:   :delete,
+                  on:   :create,
                   type: :array
       end
     end

--- a/lib/ioki/model/operator/task_list_batch.rb
+++ b/lib/ioki/model/operator/task_list_batch.rb
@@ -9,7 +9,7 @@ module Ioki
         end
 
         attribute :task_list_ids,
-                  on:   :delete,
+                  on:   :create,
                   type: :array
       end
     end


### PR DESCRIPTION
Changes the access from `delete` to `create`.