### PR TITLE
Operator API | Product feature flag for passenger names/ticket

### DIFF
--- a/lib/ioki/model/operator/features.rb
+++ b/lib/ioki/model/operator/features.rb
@@ -193,6 +193,10 @@ module Ioki
         attribute :driver_automation,
                   type: :boolean,
                   on:   :read
+
+        attribute :requires_passenger_names_or_ticket,
+                  type: :boolean,
+                  on:   :read
       end
     end
   end


### PR DESCRIPTION
Adds another product feature flag to the operator API.