### PR TITLE
Add more fleet state attributes to `Vehicle` model

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -126,6 +126,18 @@ module Ioki
                   on:             [:create, :read, :update],
                   omit_if_nil_on: [:create, :update],
                   type:           :boolean
+
+        attribute :gps_signal_missing,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :with_due_start_of_shift_task,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :driver_missing,
+                  on:   :read,
+                  type: :boolean
       end
     end
   end


### PR DESCRIPTION
This adds the attributes `gps_signal_missing`, `with_due_start_of_shift_task` and `driver_missing` to the Vehicle model.