### PR TITLE
Operator | Add `LineState` endpoint

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -387,6 +387,11 @@ module Ioki
         base_path:   [API_BASE_PATH, 'products', :id],
         model_class: Ioki::Model::Operator::StationState
       ),
+      Endpoints::ShowSingular.new(
+        :line_state,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::LineState
+      ),
       Endpoints.crud_endpoints(
         :zone,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/model/operator/line_state.rb
+++ b/lib/ioki/model/operator/line_state.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class LineState < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :limit_reached,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :lines,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Line'
+
+        attribute :line_stops,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'LineStop'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/line_state.rb
+++ b/lib/ioki/model/operator/line_state.rb
@@ -15,12 +15,12 @@ module Ioki
         attribute :lines,
                   on:         :read,
                   type:       :array,
-                  class_name: 'Line'
+                  class_name: 'LineStates::Line'
 
         attribute :line_stops,
                   on:         :read,
                   type:       :array,
-                  class_name: 'LineStop'
+                  class_name: 'LineStates::LineStop'
       end
     end
   end

--- a/lib/ioki/model/operator/line_states/line.rb
+++ b/lib/ioki/model/operator/line_states/line.rb
@@ -36,6 +36,11 @@ module Ioki
           attribute :variant,
                     on:   :read,
                     type: :string
+
+          attribute :line_stops,
+                    type:       :array,
+                    on:         :read,
+                    class_name: 'LineStates::LineStop'
         end
       end
     end

--- a/lib/ioki/model/operator/line_states/line.rb
+++ b/lib/ioki/model/operator/line_states/line.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module LineStates
+        class Line < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :slug,
+                    on:   :read,
+                    type: :string
+
+          attribute :mode,
+                    on:   :read,
+                    type: :string
+
+          attribute :route_number,
+                    on:   :read,
+                    type: :string
+
+          attribute :skip_time_window_check,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :variant,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/line_states/line_stop.rb
+++ b/lib/ioki/model/operator/line_states/line_stop.rb
@@ -1,0 +1,55 @@
+# frozen_ string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module LineStates
+        class LineStop < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :line_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :station_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :relative_time,
+                    on:   :read,
+                    type: :integer
+
+          attribute :dropoff_mode,
+                    on:   :read,
+                    type: :string
+
+          attribute :pickup_mode,
+                    on:   :read,
+                    type: :string
+
+          attribute :supports_pickup,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :supports_dropoff,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :supports_pass_through,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :tier,
+                    on:   :read,
+                    type: :integer
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/line_states/line_stop.rb
+++ b/lib/ioki/model/operator/line_states/line_stop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # frozen_ string_literal: true
 
 module Ioki

--- a/lib/ioki/model/operator/line_stop.rb
+++ b/lib/ioki/model/operator/line_stop.rb
@@ -59,6 +59,10 @@ module Ioki
                   on:   [:read, :create, :update],
                   type: :string
 
+        attribute :line_id,
+                  on:   :read,
+                  type: :string
+
         attribute :version,
                   on:   :read,
                   type: :integer

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -3050,4 +3050,15 @@ RSpec.describe Ioki::OperatorApi do
       expect(operator_client.station_state('0815', options)).to be_a Ioki::Model::Operator::StationState
     end
   end
+
+  describe '#line_state(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/line_state')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.line_state('0815', options)).to be_a Ioki::Model::Operator::LineState
+    end
+  end
 end


### PR DESCRIPTION
This adds the `line_state` endpoint and the `LineState` model.