### PR TITLE
Operator API | Add `User#failed_purchases_summary`

### DIFF
--- a/lib/ioki/model/operator/payment/failed_purchases_summary.rb
+++ b/lib/ioki/model/operator/payment/failed_purchases_summary.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Payment
+        class FailedPurchasesSummary < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :has_failed_payments,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :count,
+                    on:   :read,
+                    type: :integer
+
+          attribute :amounts,
+                    on:   :read,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/user.rb
+++ b/lib/ioki/model/operator/user.rb
@@ -121,6 +121,11 @@ module Ioki
                   on:         :read,
                   type:       :array,
                   class_name: 'PaymentMethod'
+
+        attribute :failed_purchases_summary,
+                  on:         :read,
+                  type:       :object,
+                  class_name: 'Ioki::Model::Operator::Payment::FailedPurchasesSummary'
       end
     end
   end


### PR DESCRIPTION
Adds a new submodel `failed_purchases_summary` to the `User` in the operator API.