### PR TITLE
Webhooks | Add models for line and line stop

### DIFF
--- a/lib/ioki/model/webhooks/line.rb
+++ b/lib/ioki/model/webhooks/line.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Webhooks
+      class Line < Base
+        attribute :type, type: :string
+        attribute :id, type: :string
+        attribute :created_at, type: :date_time
+        attribute :updated_at, type: :date_time
+        attribute :name, type: :string
+        attribute :slug, type: :string
+        attribute :mode, type: :string
+        attribute :route_number, type: :string
+        attribute :skip_time_window_check, type: :boolean
+        attribute :variant, type: :string
+        attribute :product_id, type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/webhooks/line_stop.rb
+++ b/lib/ioki/model/webhooks/line_stop.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Webhooks
+      class LineStop < Base
+        attribute :type, type: :string
+        attribute :id, type: :string
+        attribute :created_at, type: :date_time
+        attribute :updated_at, type: :date_time
+        attribute :relative_time, type: :integer
+        attribute :station_id, type: :string
+        attribute :line_id, type: :string
+        attribute :dropoff_mode, type: :string
+        attribute :pickup_mode, type: :string
+        attribute :supports_pickup, type: :boolean
+        attribute :supports_dropoff, type: :boolean
+        attribute :supports_pass_through, type: :boolean
+        attribute :tier, type: :integer
+        attribute :product_id, type: :string
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces two new model classes to the `lib/ioki/model/webhooks` directory, representing `Line` and `LineStop` entities for webhook events. These models define the attributes and structure needed to handle webhook data related to lines and their stops.