### PR TITLE
Operator API | Add `User#payment_methods_for_operators`

### DIFF
--- a/lib/ioki/model/operator/user.rb
+++ b/lib/ioki/model/operator/user.rb
@@ -122,6 +122,11 @@ module Ioki
                   type:       :array,
                   class_name: 'PaymentMethod'
 
+        attribute :payment_methods_for_operators,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'PaymentMethod'
+
         attribute :failed_purchases_summary,
                   on:         :read,
                   type:       :object,


### PR DESCRIPTION
Adds a new attribute to the `User` model in the operator API to return all payment methods which are bookable by operators.