### PR TITLE
Operator API | Add recently used stations

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -318,8 +318,9 @@ module Ioki
         except:      [:update, :delete]
       ),
       Endpoints::ShowSingular.new(
-        :recently_used_stations,
-        base_path:   [API_BASE_PATH, 'providers', :id, 'users', :id],
+        :users_recently_used_stations,
+        base_path:   nil,
+        path:        [API_BASE_PATH, 'providers', :id, 'users', :id, 'recently_used_stations'],
         model_class: Ioki::Model::Operator::RecentlyUsedStations
       ),
       Endpoints::Create.new(

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -317,6 +317,11 @@ module Ioki
         model_class: Ioki::Model::Operator::User,
         except:      [:update, :delete]
       ),
+      Endpoints::ShowSingular.new(
+        :recently_used_stations,
+        base_path:   [API_BASE_PATH, 'providers', :id, 'users', :id],
+        model_class: Ioki::Model::Operator::RecentlyUsedStations
+      ),
       Endpoints::Create.new(
         :ride_inquiry,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/model/operator/recently_used_stations.rb
+++ b/lib/ioki/model/operator/recently_used_stations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class RecentlyUsedStations < Base
+        attribute :destination_stations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Station'
+
+        attribute :origin_stations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Station'
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1429,14 +1429,14 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
-  describe '#recently_used_stations(provider_id, user_id)' do
+  describe '#users_recently_used_stations(provider_id, user_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('operator/providers/0815/users/4711/recently_used_stations')
         [result_with_data, full_response]
       end
 
-      expect(operator_client.recently_used_stations('0815', '4711', options))
+      expect(operator_client.users_recently_used_stations('0815', '4711', options))
         .to be_a(Ioki::Model::Operator::RecentlyUsedStations)
     end
   end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1429,6 +1429,18 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#recently_used_stations(provider_id, user_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/providers/0815/users/4711/recently_used_stations')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.recently_used_stations('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::RecentlyUsedStations)
+    end
+  end
+
   describe '#create_ride_inquiry(product_id)' do
     let(:ride_inquiry) { Ioki::Model::Operator::RideInquiry.new }
 


### PR DESCRIPTION
This adds an endpoint to the operator API to fetch recently used stations of a user.