### PR TITLE
Operator Api | VehicleState

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -52,6 +52,11 @@ module Ioki
         path:        'overview',
         model_class: Ioki::Model::Operator::Vehicle
       ),
+      Endpoints::ShowSingular.new(
+        :vehicle_state,
+        base_path:   [API_BASE_PATH, 'products', :id],
+        model_class: Ioki::Model::Operator::VehicleState
+      ),
       Endpoints::Index.new(
         :permissions,
         base_path:   [API_BASE_PATH, 'admin'],

--- a/lib/ioki/model/operator/vehicle_state.rb
+++ b/lib/ioki/model/operator/vehicle_state.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class VehicleState < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :limit_reached,
+                  on:   :read,
+                  type: :boolean
+
+        attribute :vehicles,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'VehicleStates::Vehicle'
+
+        attribute :resource_configurations,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'VehicleStates::ResourceConfiguration'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/vehicle_states/resource_configuration.rb
+++ b/lib/ioki/model/operator/vehicle_states/resource_configuration.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module VehicleStates
+        class ResourceConfiguration < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :created_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :updated_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :vehicle_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :default,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :bicycle_racks,
+                    on:   :read,
+                    type: :integer
+
+          attribute :child_booster_seat,
+                    on:   :read,
+                    type: :integer
+
+          attribute :child_safety_seat,
+                    on:   :read,
+                    type: :integer
+
+          attribute :hand_luggage_storage_spaces,
+                    on:   :read,
+                    type: :integer
+
+          attribute :medical_seats,
+                    on:   :read,
+                    type: :integer
+
+          attribute :pet_transportation_bays,
+                    on:   :read,
+                    type: :integer
+
+          attribute :power_plugs,
+                    on:   :read,
+                    type: :integer
+
+          attribute :resource_1,
+                    on:   :read,
+                    type: :integer
+
+          attribute :resource_2,
+                    on:   :read,
+                    type: :integer
+
+          attribute :resource_3,
+                    on:   :read,
+                    type: :integer
+
+          attribute :resource_4,
+                    on:   :read,
+                    type: :integer
+
+          attribute :resource_5,
+                    on:   :read,
+                    type: :integer
+
+          attribute :seats,
+                    on:   :read,
+                    type: :integer
+
+          attribute :special_seats,
+                    on:   :read,
+                    type: :integer
+
+          attribute :storage_spaces,
+                    on:   :read,
+                    type: :integer
+
+          attribute :suitcase_storage_spaces,
+                    on:   :read,
+                    type: :integer
+
+          attribute :walker_bays,
+                    on:   :read,
+                    type: :integer
+
+          attribute :walker_storage_spaces,
+                    on:   :read,
+                    type: :integer
+
+          attribute :wheelchair_bays,
+                    on:   :read,
+                    type: :integer
+
+          attribute :wheelchair_storage_spaces,
+                    on:   :read,
+                    type: :integer
+
+          attribute :wlan_access_points,
+                    on:   :read,
+                    type: :integer
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/vehicle_states/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle_states/vehicle.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module VehicleStates
+        class Vehicle < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :id,
+                    on:   :read,
+                    type: :string
+
+          attribute :created_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :updated_at,
+                    on:   :read,
+                    type: :date_time
+
+          attribute :autonomous,
+                    on:   :read,
+                    type: :boolean
+
+          attribute :description,
+                    on:   :read,
+                    type: :string
+
+          attribute :external_id,
+                    on:   :read,
+                    type: :string
+
+          attribute :fuel_type,
+                    on:   :read,
+                    type: :string
+
+          attribute :license_plate,
+                    on:   :read,
+                    type: :string
+
+          attribute :manufacturer,
+                    on:   :read,
+                    type: :string
+
+          attribute :matching_rank,
+                    on:   :read,
+                    type: :integer
+
+          attribute :model,
+                    on:   :read,
+                    type: :string
+
+          attribute :nickname,
+                    on:   :read,
+                    type: :string
+
+          attribute :phone_number,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -3387,4 +3387,15 @@ RSpec.describe Ioki::OperatorApi do
         .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
     end
   end
+
+  describe '#vehicle_state(product_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/vehicle_state')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.vehicle_state('0815', options)).to be_a Ioki::Model::Operator::VehicleState
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces support for a new `vehicle_state` endpoint in the Operator API and adds the corresponding model classes to represent vehicle state data, including vehicles and their resource configurations. It also includes tests to verify the new functionality.