### PR TITLE
Operator API | Aggregations

### DIFF
--- a/lib/ioki/apis/endpoints/create.rb
+++ b/lib/ioki/apis/endpoints/create.rb
@@ -36,7 +36,7 @@ module Ioki
         parsed_response, response = client.request(
           url:    client.build_request_url(*Endpoints.url_elements(full_path, *args)),
           method: :post,
-          body:   { data: model&.serialize(:create) },
+          body:   { data: model&.serialize(:create, format: :json) },
           params: options[:params]
         )
 

--- a/lib/ioki/apis/endpoints/delete.rb
+++ b/lib/ioki/apis/endpoints/delete.rb
@@ -33,7 +33,7 @@ module Ioki
           raise(ArgumentError, "#{model} is not an instance of #{outgoing_model_class}")
         end
 
-        body = (@send_body && model) ? { data: model.serialize(:delete) } : nil
+        body = (@send_body && model) ? { data: model.serialize(:delete, format: :json) } : nil
 
         parsed_response, = client.request(
           url:    client.build_request_url(*Endpoints.url_elements(full_path, *args)),

--- a/lib/ioki/apis/endpoints/driver/create_vehicle_connection.rb
+++ b/lib/ioki/apis/endpoints/driver/create_vehicle_connection.rb
@@ -20,7 +20,7 @@ module Ioki
           client.request(
             url:    client.build_request_url('driver', 'vehicle_connection'),
             method: :post,
-            body:   { data: model.serialize(:create) }
+            body:   { data: model.serialize(:create, format: :json) }
           )
         end
       end

--- a/lib/ioki/apis/endpoints/driver/delete_vehicle_connection.rb
+++ b/lib/ioki/apis/endpoints/driver/delete_vehicle_connection.rb
@@ -21,7 +21,7 @@ module Ioki
           client.request(
             url:    client.build_request_url('driver', 'vehicle_connection'),
             method: :delete,
-            body:   { data: model.serialize(:create) }
+            body:   { data: model.serialize(:create, format: :json) }
           )
         end
       end

--- a/lib/ioki/apis/endpoints/driver/vehicle_position.rb
+++ b/lib/ioki/apis/endpoints/driver/vehicle_position.rb
@@ -20,7 +20,7 @@ module Ioki
           client.request(
             url:    client.build_request_url('driver', 'vehicle', 'positions'),
             method: :post,
-            body:   { data: model.serialize(:create) }
+            body:   { data: model.serialize(:create, format: :json) }
           )
         end
       end

--- a/lib/ioki/apis/endpoints/update.rb
+++ b/lib/ioki/apis/endpoints/update.rb
@@ -35,7 +35,7 @@ module Ioki
         parsed_response, response = client.request(
           url:    client.build_request_url(*Endpoints.url_elements(full_path, *args)),
           method: :patch,
-          body:   { data: model.serialize(:update) },
+          body:   { data: model.serialize(:update, format: :json) },
           params: options[:params]
         )
 

--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -457,6 +457,21 @@ module Ioki
         ],
         model_class: Ioki::Model::Operator::Reporting::ReportPartition
       ),
+      Endpoints::Index.new(
+        :reporting_aggregations,
+        base_path:   [API_BASE_PATH, 'reporting', 'report', 'scopes', :scope, 'reports', :name],
+        path:        'aggregations',
+        model_class: Ioki::Model::Operator::Reporting::ReportAggregation
+      ),
+      Endpoints::Create.new(
+        :reporting_aggregation_query,
+        base_path:            [
+          API_BASE_PATH, 'reporting', 'report', 'scopes', :scope, 'reports', :name, 'aggregations', :aggregation_name
+        ],
+        path:                 'aggregate',
+        model_class:          Ioki::Model::Operator::Reporting::ReportAggregationResult,
+        outgoing_model_class: Ioki::Model::Operator::Reporting::ReportAggregationQuery
+      ),
       Endpoints.crud_endpoints(
         :cancellation_statement,
         base_path:   [API_BASE_PATH, 'products', :id],

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -181,9 +181,11 @@ module Ioki
 
       # may get overridden in hard ways by subclasses. This default
       # implementation should bring us a long way.
-      def serialize(usecase = :read, only_changed: true)
+      def serialize(usecase = :read, only_changed: true, format: :ruby)
         if !@_raw_attributes.is_a?(Hash)
-          return @_raw_attributes.map { |object| object.serialize(usecase) } if @_raw_attributes.is_a?(Array)
+          if @_raw_attributes.is_a?(Array)
+            return @_raw_attributes.map { |object| object.serialize(usecase, format: format) }
+          end
 
           return @_raw_attributes
         end
@@ -210,11 +212,11 @@ module Ioki
                   !@_initial_attributes.key?(attribute)
 
           data[attribute] = if definition[:type] == :object && value.is_a?(Ioki::Model::Base)
-                              value.serialize(usecase)
+                              value.serialize(usecase, format: format)
                             elsif definition[:type] == :array && value.respond_to?(:map)
-                              value.map { |el| el.is_a?(Ioki::Model::Base) ? el.serialize(usecase) : el }
+                              value.map { |el| el.is_a?(Ioki::Model::Base) ? el.serialize(usecase, format: format) : serialize_as_type(definition[:type], el, format: format) }
                             else
-                              value
+                              serialize_as_type(definition[:type], value, format: format)
                             end
         end
       end
@@ -310,6 +312,17 @@ module Ioki
           end
         else
           raise "Unknown type #{type}"
+        end
+      end
+
+      def serialize_as_type(type, value, format: :ruby)
+        return value if format == :ruby
+
+        case type
+        when :date_time
+          value.respond_to?(:iso8601) ? value.iso8601 : value
+        else
+          value
         end
       end
 

--- a/lib/ioki/model/operator/geojson.rb
+++ b/lib/ioki/model/operator/geojson.rb
@@ -11,7 +11,7 @@ module Ioki
         attribute :coordinates, type: :array, on: [:create, :read, :update]
         attribute :type, type: :string, on: [:create, :read, :update]
 
-        def serialize(usecase = :read, only_changed: true)
+        def serialize(usecase = :read, only_changed: true, format: :ruby)
           case usecase
           when :read then super
           else @_raw_attributes.to_json

--- a/lib/ioki/model/operator/reporting/report_aggregation.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregation < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :visualization,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_visualization,
+                    on:   :read,
+                    type: :string
+
+          attribute :release_stage,
+                    on:   :read,
+                    type: :string
+
+          attribute :bucket,
+                    on:         :read,
+                    type:       :object,
+                    class_name: 'ReportAggregationBucket'
+
+          attribute :measures,
+                    on:         :read,
+                    type:       :array,
+                    class_name: 'ReportAggregationMeasure'
+
+          attribute :dimensions,
+                    on:         :read,
+                    type:       :array,
+                    class_name: 'ReportAggregationDimension'
+
+          attribute :filters,
+                    on:         :read,
+                    type:       :array,
+                    class_name: 'ReportAggregationFilter'
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_bucket.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_bucket.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationBucket < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :granularities,
+                    on:   :read,
+                    type: :array
+
+          attribute :localized_granularities,
+                    on:   :read,
+                    type: :array
+
+          attribute :presets,
+                    on:   :read,
+                    type: :array
+
+          attribute :localized_presets,
+                    on:   :read,
+                    type: :array
+
+          attribute :default_preset,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_dimension.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_dimension.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationDimension < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_label,
+                    on:   :read,
+                    type: :string
+
+          attribute :values,
+                    on:   :read,
+                    type: :array
+
+          attribute :localized_values,
+                    on:   :read,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_filter.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_filter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationFilter < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_label,
+                    on:   :read,
+                    type: :string
+
+          attribute :values,
+                    on:   :read,
+                    type: :array
+
+          attribute :localized_values,
+                    on:   :read,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_filter_param.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_filter_param.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationFilterParam < Base
+          attribute :name,
+                    on:   :create,
+                    type: :string
+
+          attribute :values,
+                    on:   :create,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationMeasure < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :name,
+                    on:   :read,
+                    type: :string
+
+          attribute :function,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_function,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_label,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_type,
+                    on:   :read,
+                    type: :string
+
+          attribute :value_type,
+                    on:   :read,
+                    type: :string
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_measure_series.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_measure_series.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationMeasureSeries < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :key,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_label,
+                    on:   :read,
+                    type: :string
+
+          attribute :points,
+                    on:   :read,
+                    type: :array
+
+          attribute :trend,
+                    on:   :read,
+                    type: :float
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_query.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationQuery < Base
+          attribute :start_time,
+                    on:   :create,
+                    type: :date_time
+
+          attribute :end_time,
+                    on:   :create,
+                    type: :date_time
+
+          attribute :bucket,
+                    on:             :create,
+                    type:           :string,
+                    omit_if_nil_on: :create
+
+          attribute :filters,
+                    on:             :create,
+                    type:           :array,
+                    class_name:     'ReportAggregationFilterParam',
+                    omit_if_nil_on: :create
+        end
+      end
+    end
+  end
+end

--- a/lib/ioki/model/operator/reporting/report_aggregation_result.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_result.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      module Reporting
+        class ReportAggregationResult < Base
+          attribute :type,
+                    on:   :read,
+                    type: :string
+
+          attribute :aggregation_name,
+                    on:   :read,
+                    type: :string
+
+          attribute :visualization,
+                    on:   :read,
+                    type: :string
+
+          attribute :timezone_identifier,
+                    on:   :read,
+                    type: :string
+
+          attribute :buckets,
+                    on:   :read,
+                    type: :array
+
+          attribute :bucket,
+                    on:   :read,
+                    type: :string
+
+          attribute :measures,
+                    on:         :read,
+                    type:       :array,
+                    class_name: 'ReportAggregationMeasureSeries'
+
+          attribute :partitions_considered,
+                    on:   :read,
+                    type: :integer
+
+          attribute :definition_versions,
+                    on:   :read,
+                    type: :array
+        end
+      end
+    end
+  end
+end

--- a/spec/ioki/driver_api_spec.rb
+++ b/spec/ioki/driver_api_spec.rb
@@ -130,7 +130,9 @@ RSpec.describe Ioki::DriverApi do
       expect(driver_client).to receive(:request) do |params|
         expect(params[:url].to_s).to eq('driver/vehicle/positions')
         expect(params[:method]).to eq(:post)
-        expect(params[:body]).to include(data: hash_including(lat: 1.0, lng: 2.0, recorded_at: be_a(DateTime)))
+        expect(params[:body]).to include(data: hash_including(
+          lat: 1.0, lng: 2.0, recorded_at: '2012-12-12T12:12:12+00:00'
+        ))
         [nil, full_response]
       end
 

--- a/spec/ioki/endpoints/create_spec.rb
+++ b/spec/ioki/endpoints/create_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Ioki::Endpoints::Create do
   let(:params)           { instance_double(Hash, 'params') }
   let(:serialized_model) { { name: 'Test' } }
 
-  before { allow(model).to receive(:serialize).with(:create).and_return(serialized_model) }
+  before { allow(model).to receive(:serialize).with(:create, format: :json).and_return(serialized_model) }
 
   describe '#call' do
     let(:response) do

--- a/spec/ioki/endpoints/delete_spec.rb
+++ b/spec/ioki/endpoints/delete_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Ioki::Endpoints::Delete do
     let(:serialized_model) { { name: 'To be deleted' } }
     let(:send_body) { true }
 
-    before { allow(model).to receive(:serialize).with(:delete).and_return(serialized_model) }
+    before { allow(model).to receive(:serialize).with(:delete, format: :json).and_return(serialized_model) }
 
     context 'and send_body is false' do
       let(:send_body) { false }

--- a/spec/ioki/endpoints/update_spec.rb
+++ b/spec/ioki/endpoints/update_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Ioki::Endpoints::Update do
       ]
     end
 
-    before { allow(model).to receive(:serialize).with(:update).and_return(serialized_model) }
+    before { allow(model).to receive(:serialize).with(:update, format: :json).and_return(serialized_model) }
 
     it 'is a shortcut calling #request, sending serialized modeldata and instantiating a new class from the result' do
       expect(client).to receive(:request).with(

--- a/spec/ioki/model/base_spec.rb
+++ b/spec/ioki/model/base_spec.rb
@@ -367,6 +367,38 @@ RSpec.describe Ioki::Model::Base do
         )
       end
 
+      it 'does not serialize objects with a ruby format' do
+        expect(model.serialize(:read, format: :ruby)).to eq(
+          {
+            foo: '1',
+            bar: '2',
+            baz: 3,
+            bam: 4.0,
+            brk: false,
+            baf: DateTime.parse('2020-01-01 12:34:56 +0200'),
+            bak: {
+              'lol' => '42'
+            }
+          }
+        )
+      end
+
+      it 'allows to force JSON output' do
+        expect(model.serialize(:read, format: :json)).to eq(
+          {
+            foo: '1',
+            bar: '2',
+            baz: 3,
+            bam: 4.0,
+            brk: false,
+            baf: '2020-01-01T12:34:56+02:00',
+            bak: {
+              'lol' => '42'
+            }
+          }
+        )
+      end
+
       context 'without all attributes' do
         let(:example_class) do
           Class.new(Ioki::Model::Base) do

--- a/spec/ioki/model/operator/reporting/report_aggregation_bucket_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_bucket_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationBucket do
+  subject(:bucket) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:                    'reporting/report_aggregation_bucket',
+      granularities:           %w[hour day week month],
+      localized_granularities: %w[Hourly Daily Weekly Monthly],
+      presets:                 %w[last_7_days last_28_days last_6_months last_12_months month_to_date],
+      localized_presets:       ['Last 7 days', 'Last 28 days', 'Last 6 months', 'Last 12 months', 'Month to date'],
+      default_preset:          'last_7_days'
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:granularities).as(:array) }
+  it { is_expected.to define_attribute(:localized_granularities).as(:array) }
+  it { is_expected.to define_attribute(:presets).as(:array) }
+  it { is_expected.to define_attribute(:localized_presets).as(:array) }
+  it { is_expected.to define_attribute(:default_preset).as(:string) }
+
+  it 'casts all bucket metadata' do
+    expect(bucket.granularities).to eq(%w[hour day week month])
+    expect(bucket.localized_granularities).to eq(%w[Hourly Daily Weekly Monthly])
+    expect(bucket.presets).to eq(%w[last_7_days last_28_days last_6_months last_12_months month_to_date])
+    expect(bucket.localized_presets).to eq(
+      ['Last 7 days', 'Last 28 days', 'Last 6 months', 'Last 12 months', 'Month to date']
+    )
+    expect(bucket.default_preset).to eq('last_7_days')
+  end
+
+  it 'accepts a nullable default preset' do
+    expect(described_class.new(attributes.merge(default_preset: nil)).default_preset).to be_nil
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_dimension_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_dimension_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationDimension do
+  subject(:dimension) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:             'reporting/report_aggregation_dimension',
+      name:             'booking_type',
+      localized_label:  'Booking type',
+      values:           %w[prebooked adhoc],
+      localized_values: ['Prebooked', 'Ad hoc']
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:localized_label).as(:string) }
+  it { is_expected.to define_attribute(:values).as(:array) }
+  it { is_expected.to define_attribute(:localized_values).as(:array) }
+
+  it 'casts dimension metadata' do
+    expect(dimension.name).to eq('booking_type')
+    expect(dimension.localized_label).to eq('Booking type')
+    expect(dimension.values).to eq(%w[prebooked adhoc])
+    expect(dimension.localized_values).to eq(['Prebooked', 'Ad hoc'])
+  end
+
+  it 'accepts unknown values metadata' do
+    unknown_values_dimension = described_class.new(attributes.merge(values: nil, localized_values: nil))
+
+    expect(unknown_values_dimension.values).to be_nil
+    expect(unknown_values_dimension.localized_values).to be_nil
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_filter_param_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_filter_param_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationFilterParam do
+  subject(:filter_param) { described_class.new(name: 'booking_type', values: %w[prebooked adhoc]) }
+
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:values).as(:array) }
+
+  it 'serializes filter params for aggregation queries' do
+    expect(filter_param.serialize(:create)).to eq(
+      name:   'booking_type',
+      values: %w[prebooked adhoc]
+    )
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_filter_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_filter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationFilter do
+  subject(:filter) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:             'reporting/report_aggregation_filter',
+      name:             'operator_id',
+      localized_label:  'Operator',
+      values:           %w[op-1 op-2],
+      localized_values: %w[Op-1 Op-2]
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:localized_label).as(:string) }
+  it { is_expected.to define_attribute(:values).as(:array) }
+  it { is_expected.to define_attribute(:localized_values).as(:array) }
+
+  it 'casts filter metadata' do
+    expect(filter.name).to eq('operator_id')
+    expect(filter.localized_label).to eq('Operator')
+    expect(filter.values).to eq(%w[op-1 op-2])
+    expect(filter.localized_values).to eq(%w[Op-1 Op-2])
+  end
+
+  it 'accepts unrestricted filter values' do
+    unrestricted_filter = described_class.new(attributes.merge(values: nil, localized_values: nil))
+
+    expect(unrestricted_filter.values).to be_nil
+    expect(unrestricted_filter.localized_values).to be_nil
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_measure_series_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_measure_series_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationMeasureSeries do
+  subject(:measure_series) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:            'reporting/report_aggregation_measure_series',
+      key:             'login_count',
+      localized_label: 'Logins',
+      points:          [10.0, nil],
+      trend:           12.5
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:key).as(:string) }
+  it { is_expected.to define_attribute(:localized_label).as(:string) }
+  it { is_expected.to define_attribute(:points).as(:array) }
+  it { is_expected.to define_attribute(:trend).as(:float) }
+
+  it 'casts measure series metadata' do
+    expect(measure_series.key).to eq('login_count')
+    expect(measure_series.localized_label).to eq('Logins')
+    expect(measure_series.points).to eq([10.0, nil])
+    expect(measure_series.trend).to eq(12.5)
+  end
+
+  it 'accepts nullable trends' do
+    expect(described_class.new(attributes.merge(trend: nil)).trend).to be_nil
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_measure_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_measure_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationMeasure do
+  subject(:measure) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:               'reporting/report_aggregation_measure',
+      name:               'login_count',
+      function:           'count_rows',
+      localized_function: 'Count',
+      localized_label:    'Logins',
+      localized_type:     'Count',
+      value_type:         'number'
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:function).as(:string) }
+  it { is_expected.to define_attribute(:localized_function).as(:string) }
+  it { is_expected.to define_attribute(:localized_label).as(:string) }
+  it { is_expected.to define_attribute(:localized_type).as(:string) }
+  it { is_expected.to define_attribute(:value_type).as(:string) }
+
+  it 'casts measure metadata' do
+    expect(measure.name).to eq('login_count')
+    expect(measure.function).to eq('count_rows')
+    expect(measure.localized_function).to eq('Count')
+    expect(measure.localized_label).to eq('Logins')
+    expect(measure.localized_type).to eq('Count')
+    expect(measure.value_type).to eq('number')
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_query_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_query_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationQuery do
+  let(:start_time) { DateTime.parse('2026-04-01T00:00:00Z') }
+  let(:end_time) { DateTime.parse('2026-05-01T00:00:00Z') }
+
+  it { is_expected.to define_attribute(:start_time).as(:date_time) }
+  it { is_expected.to define_attribute(:end_time).as(:date_time) }
+  it { is_expected.to define_attribute(:bucket).as(:string) }
+  it { is_expected.to define_attribute(:filters).as(:array).with(class_name: 'ReportAggregationFilterParam') }
+
+  it 'serializes the raw aggregation query payload' do
+    query = described_class.new(
+      start_time: start_time,
+      end_time:   end_time,
+      bucket:     'day',
+      filters:    [
+        Ioki::Model::Operator::Reporting::ReportAggregationFilterParam.new(
+          name:   'booking_type',
+          values: %w[prebooked adhoc]
+        )
+      ]
+    )
+
+    expect(query.serialize(:create)).to eq(
+      start_time: start_time,
+      end_time:   end_time,
+      bucket:     'day',
+      filters:    [
+        {
+          name:   'booking_type',
+          values: %w[prebooked adhoc]
+        }
+      ]
+    )
+  end
+
+  it 'omits optional attributes when they are not set' do
+    query = described_class.new(start_time: start_time, end_time: end_time)
+
+    expect(query.serialize(:create)).to eq(
+      start_time: start_time,
+      end_time:   end_time
+    )
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_result_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_result_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationResult do
+  subject(:result) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:                  'reporting/report_aggregation_result',
+      aggregation_name:      'admin_logins',
+      visualization:         'bar',
+      timezone_identifier:   'Europe/Berlin',
+      buckets:               %w[2026-04-01 2026-04-02],
+      bucket:                'day',
+      measures:              [
+        {
+          type:            'reporting/report_aggregation_measure_series',
+          key:             'login_count',
+          localized_label: 'Logins',
+          points:          [10.0, 20.0],
+          trend:           nil
+        }
+      ],
+      partitions_considered: 2,
+      definition_versions:   [1]
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:aggregation_name).as(:string) }
+  it { is_expected.to define_attribute(:visualization).as(:string) }
+  it { is_expected.to define_attribute(:timezone_identifier).as(:string) }
+  it { is_expected.to define_attribute(:buckets).as(:array) }
+  it { is_expected.to define_attribute(:bucket).as(:string) }
+
+  it do
+    is_expected.to define_attribute(:measures).as(:array).with(class_name: 'ReportAggregationMeasureSeries')
+  end
+
+  it { is_expected.to define_attribute(:partitions_considered).as(:integer) }
+  it { is_expected.to define_attribute(:definition_versions).as(:array) }
+
+  it 'casts measure series into reporting models' do
+    expect(result.aggregation_name).to eq('admin_logins')
+    expect(result.visualization).to eq('bar')
+    expect(result.timezone_identifier).to eq('Europe/Berlin')
+    expect(result.buckets).to eq(%w[2026-04-01 2026-04-02])
+    expect(result.bucket).to eq('day')
+    expect(result.measures.first).to be_a(Ioki::Model::Operator::Reporting::ReportAggregationMeasureSeries)
+    expect(result.measures.first.localized_label).to eq('Logins')
+    expect(result.partitions_considered).to eq(2)
+    expect(result.definition_versions).to eq([1])
+  end
+
+  it 'accepts nullable bucket metadata and measure trends' do
+    aggregation_result = described_class.new(
+      attributes.merge(
+        bucket:   nil,
+        measures: [attributes[:measures].first.merge(trend: 12.5)]
+      )
+    )
+
+    expect(aggregation_result.bucket).to be_nil
+    expect(aggregation_result.measures.first.trend).to eq(12.5)
+  end
+end

--- a/spec/ioki/model/operator/reporting/report_aggregation_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregation do
+  subject(:report_aggregation) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      type:                    'reporting/report_aggregation',
+      name:                    'admin_logins',
+      visualization:           'bar',
+      localized_visualization: 'Bar chart',
+      release_stage:           'stable',
+      bucket:                  {
+        type:                    'reporting/report_aggregation_bucket',
+        granularities:           ['day', 'week'],
+        localized_granularities: ['Daily', 'Weekly'],
+        presets:                 ['last_7_days'],
+        localized_presets:       ['Last 7 days'],
+        default_preset:          'last_7_days'
+      },
+      measures:                [
+        {
+          type:               'reporting/report_aggregation_measure',
+          name:               'rides',
+          function:           'count_rows',
+          localized_function: 'Count',
+          localized_label:    'Rides',
+          localized_type:     'Count',
+          value_type:         'number'
+        }
+      ],
+      dimensions:              [
+        {
+          type:             'reporting/report_aggregation_dimension',
+          name:             'booking_type',
+          localized_label:  'Booking type',
+          values:           ['prebooked', 'adhoc'],
+          localized_values: ['Prebooked', 'Ad hoc']
+        }
+      ],
+      filters:                 [
+        {
+          type:             'reporting/report_aggregation_filter',
+          name:             'operator_id',
+          localized_label:  'Operator',
+          values:           ['operator_1'],
+          localized_values: ['Operator 1']
+        }
+      ]
+    }
+  end
+
+  it { is_expected.to define_attribute(:type).as(:string) }
+  it { is_expected.to define_attribute(:name).as(:string) }
+  it { is_expected.to define_attribute(:visualization).as(:string) }
+  it { is_expected.to define_attribute(:localized_visualization).as(:string) }
+  it { is_expected.to define_attribute(:release_stage).as(:string) }
+  it { is_expected.to define_attribute(:bucket).as(:object).with(class_name: 'ReportAggregationBucket') }
+  it { is_expected.to define_attribute(:measures).as(:array).with(class_name: 'ReportAggregationMeasure') }
+  it { is_expected.to define_attribute(:dimensions).as(:array).with(class_name: 'ReportAggregationDimension') }
+  it { is_expected.to define_attribute(:filters).as(:array).with(class_name: 'ReportAggregationFilter') }
+
+  it 'casts nested aggregation data into reporting models' do
+    expect(report_aggregation.name).to eq('admin_logins')
+    expect(report_aggregation.visualization).to eq('bar')
+    expect(report_aggregation.localized_visualization).to eq('Bar chart')
+    expect(report_aggregation.release_stage).to eq('stable')
+    expect(report_aggregation.bucket).to be_a(Ioki::Model::Operator::Reporting::ReportAggregationBucket)
+    expect(report_aggregation.bucket.localized_granularities).to eq(['Daily', 'Weekly'])
+    expect(report_aggregation.bucket.localized_presets).to eq(['Last 7 days'])
+    expect(report_aggregation.measures.first).to be_a(
+      Ioki::Model::Operator::Reporting::ReportAggregationMeasure
+    )
+    expect(report_aggregation.measures.first.value_type).to eq('number')
+    expect(report_aggregation.measures.first.localized_label).to eq('Rides')
+    expect(report_aggregation.dimensions.first).to be_a(
+      Ioki::Model::Operator::Reporting::ReportAggregationDimension
+    )
+    expect(report_aggregation.dimensions.first.localized_values).to eq(['Prebooked', 'Ad hoc'])
+    expect(report_aggregation.filters.first).to be_a(Ioki::Model::Operator::Reporting::ReportAggregationFilter)
+    expect(report_aggregation.filters.first.localized_label).to eq('Operator')
+  end
+
+  it 'accepts nullable bucket and known values metadata' do
+    aggregation = described_class.new(
+      attributes.merge(
+        bucket:     nil,
+        dimensions: [
+          {
+            type:             'reporting/report_aggregation_dimension',
+            name:             'booking_type',
+            localized_label:  'Booking type',
+            values:           nil,
+            localized_values: nil
+          }
+        ],
+        filters:    [
+          {
+            type:             'reporting/report_aggregation_filter',
+            name:             'operator_id',
+            localized_label:  'Operator',
+            values:           nil,
+            localized_values: nil
+          }
+        ]
+      )
+    )
+
+    expect(aggregation.bucket).to be_nil
+    expect(aggregation.dimensions.first.values).to be_nil
+    expect(aggregation.dimensions.first.localized_values).to be_nil
+    expect(aggregation.filters.first.values).to be_nil
+    expect(aggregation.filters.first.localized_values).to be_nil
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1988,7 +1988,7 @@ RSpec.describe Ioki::OperatorApi do
         expect(params[:url].to_s)
           .to eq('operator/reporting/report/scopes/myscope/reports/myname/aggregations/ride_counts/aggregate')
         expect(params[:method]).to eq(:post)
-        expect(params[:body]).to eq({ data: query.serialize(:create) })
+        expect(params[:body]).to eq({ data: query.serialize(:create, format: :json) })
         [result_with_reporting_aggregation, full_response]
       end
 

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1878,6 +1878,138 @@ RSpec.describe Ioki::OperatorApi do
     end
   end
 
+  describe '#reporting_aggregations(scope, name)' do
+    let(:result_with_reporting_aggregations) do
+      {
+        'data' => [
+          {
+            type:                    'reporting/report_aggregation',
+            name:                    'admin_logins',
+            visualization:           'bar',
+            localized_visualization: 'Bar chart',
+            release_stage:           'stable',
+            bucket:                  {
+              type:                    'reporting/report_aggregation_bucket',
+              granularities:           %w[hour day week month],
+              localized_granularities: %w[Hourly Daily Weekly Monthly],
+              presets:                 %w[
+                last_7_days
+                last_28_days
+                last_6_months
+                last_12_months
+                month_to_date
+              ],
+              localized_presets:       [
+                'Last 7 days',
+                'Last 4 weeks',
+                'Last 6 months',
+                'Last 12 months',
+                'Month to date'
+              ],
+              default_preset:          'last_7_days'
+            },
+            measures:                [
+              {
+                type:               'reporting/report_aggregation_measure',
+                name:               'login_count',
+                function:           'count_rows',
+                localized_function: 'Count',
+                localized_label:    'Logins',
+                localized_type:     'Count',
+                value_type:         'number'
+              }
+            ],
+            dimensions:              [],
+            filters:                 []
+          }
+        ]
+      }
+    end
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s)
+          .to eq('operator/reporting/report/scopes/myscope/reports/myname/aggregations')
+        result_with_reporting_aggregations
+      end
+
+      aggregations = operator_client.reporting_aggregations('myscope', 'myname', options)
+
+      expect(aggregations).to all(be_a(Ioki::Model::Operator::Reporting::ReportAggregation))
+      expect(aggregations.first.name).to eq('admin_logins')
+      expect(aggregations.first.localized_visualization).to eq('Bar chart')
+      expect(aggregations.first.release_stage).to eq('stable')
+      expect(aggregations.first.bucket.default_preset).to eq('last_7_days')
+      expect(aggregations.first.measures.first.localized_label).to eq('Logins')
+    end
+  end
+
+  describe '#create_reporting_aggregation_query(scope, name, aggregation_name, query)' do
+    let(:query) do
+      Ioki::Model::Operator::Reporting::ReportAggregationQuery.new(
+        start_time: DateTime.parse('2026-04-01T00:00:00Z'),
+        end_time:   DateTime.parse('2026-05-01T00:00:00Z'),
+        bucket:     'day',
+        filters:    [
+          Ioki::Model::Operator::Reporting::ReportAggregationFilterParam.new(
+            name:   'booking_type',
+            values: %w[prebooked adhoc]
+          )
+        ]
+      )
+    end
+
+    let(:result_with_reporting_aggregation) do
+      {
+        'data' => {
+          type:                  'reporting/report_aggregation_result',
+          aggregation_name:      'admin_logins',
+          visualization:         'bar',
+          timezone_identifier:   'Europe/Berlin',
+          buckets:               %w[2026-04-01 2026-04-02],
+          bucket:                'day',
+          measures:              [
+            {
+              type:            'reporting/report_aggregation_measure_series',
+              key:             'login_count',
+              localized_label: 'Logins',
+              points:          [10, 20],
+              trend:           nil
+            }
+          ],
+          partitions_considered: 2,
+          definition_versions:   [1]
+        }
+      }
+    end
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s)
+          .to eq('operator/reporting/report/scopes/myscope/reports/myname/aggregations/ride_counts/aggregate')
+        expect(params[:method]).to eq(:post)
+        expect(params[:body]).to eq({ data: query.serialize(:create) })
+        [result_with_reporting_aggregation, full_response]
+      end
+
+      aggregation_result = operator_client.create_reporting_aggregation_query(
+        'myscope',
+        'myname',
+        'ride_counts',
+        query,
+        options
+      )
+
+      expect(aggregation_result).to be_a(Ioki::Model::Operator::Reporting::ReportAggregationResult)
+      expect(aggregation_result.aggregation_name).to eq('admin_logins')
+      expect(aggregation_result.timezone_identifier).to eq('Europe/Berlin')
+      expect(aggregation_result.bucket).to eq('day')
+      expect(aggregation_result.measures.first.localized_label).to eq('Logins')
+      expect(aggregation_result.partitions_considered).to eq(2)
+      expect(aggregation_result.definition_versions).to eq([1])
+    end
+  end
+
   describe '#cancellation_statements(product_id)' do
     it 'calls request on the client with expected params' do
       expect(operator_client).to receive(:request) do |params|


### PR DESCRIPTION
Adds aggregation endpoints to the operator API.

## Breaking change

Currently, when sending a timestamp to the API via a `Ioki::Model`, the timestamp is sent as `to_s`, e.g.: `2026-06-02 11:57:06 +0200`. This format is then rejected by the API as non-ISO8601.

In some projects this was solved by calling `ios8601` on the date object before passing the `Ioki::Model` to the ioki-ruby client. With the following change, this will no longer be necessary.

When sending a `POST`, `PATCH` or `DELETE` request, we now serialize timestamps correctly as ISO8601. To keep the change minimal, we only do that if the attribute is of type `datetime`. We also check whether the value has a `iso8601` method.

Clients which call `iso8601` on their own are not affected. This still works, but they could remove their manual `iso8601` call.

This should therefore not be a breaking change - but still mentioned as potentially breaking.