### PR TITLE
Switch mailer to use new recipient options in api

### DIFF
--- a/lib/ioki/mailing/mailer.rb
+++ b/lib/ioki/mailing/mailer.rb
@@ -30,7 +30,7 @@ module Ioki
         email_delivery = Ioki::Model::Platform::EmailDelivery.new(
           delivery_context: delivery_context,
           mime_message:     mail.encoded,
-          user_id:          mail.ioki_options[:user_id]
+          **recipient_options(mail.ioki_options)
         )
 
         platform_client.create_email_delivery(provider, email_delivery)
@@ -42,6 +42,14 @@ module Ioki
         return false unless options
 
         !!(options[:platform_client] && options[:provider_id])
+      end
+
+      def recipient_options(options)
+        if options[:user_id]
+          { recipient_id: options[:user_id], recipient_type: 'User' }
+        else
+          { recipient_id: options[:recipient_id], recipient_type: options[:recipient_type] }
+        end
       end
     end
   end

--- a/lib/ioki/model/platform/email_delivery.rb
+++ b/lib/ioki/model/platform/email_delivery.rb
@@ -12,10 +12,10 @@ module Ioki
         attribute :recipient_id, on: :create, type: :string, omit_if_nil_on: :create
         attribute :recipient_type, on: :create, type: :string, omit_if_nil_on: :create
         deprecated_attribute :user_id,
-                             on: :create,
-                             type: :string,
+                             on:             :create,
+                             type:           :string,
                              omit_if_nil_on: :create,
-                             replaced_by: :recipient_id
+                             replaced_by:    :recipient_id
         attribute :mime_message, on: :create, type: :string
       end
     end

--- a/lib/ioki/model/platform/email_delivery.rb
+++ b/lib/ioki/model/platform/email_delivery.rb
@@ -9,7 +9,13 @@ module Ioki
         end
 
         attribute :delivery_context, on: :create, type: :string
-        attribute :user_id, on: :create, type: :string, omit_if_nil_on: :create
+        attribute :recipient_id, on: :create, type: :string, omit_if_nil_on: :create
+        attribute :recipient_type, on: :create, type: :string, omit_if_nil_on: :create
+        deprecated_attribute :user_id,
+                             on: :create,
+                             type: :string,
+                             omit_if_nil_on: :create,
+                             replaced_by: :recipient_id
         attribute :mime_message, on: :create, type: :string
       end
     end

--- a/spec/ioki/mailing/mailer_spec.rb
+++ b/spec/ioki/mailing/mailer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Ioki::Mailing::Mailer do
       without_partial_double_verification do
         expect(platform_client).to receive(:create_email_delivery).with(
           have_attributes(id: 'prv_1'),
-          have_attributes(delivery_context: 'registration', user_id: nil)
+          have_attributes(delivery_context: 'registration', recipient_id: nil, recipient_type: nil)
         )
       end
 
@@ -50,7 +50,32 @@ RSpec.describe Ioki::Mailing::Mailer do
       without_partial_double_verification do
         expect(platform_client).to receive(:create_email_delivery).with(
           have_attributes(id: 'prv_1'),
-          have_attributes(delivery_context: 'standard', user_id: 'usr_1')
+          have_attributes(delivery_context: 'standard', recipient_id: 'usr_1', recipient_type: 'User')
+        )
+      end
+
+      subject
+    end
+  end
+
+  context 'with recipient_id and recipient_type' do
+    let(:mail) do
+      Mail::Message.new.tap do |message|
+        message.ioki_options = {
+          provider_id:      'prv_1',
+          platform_client:  platform_client,
+          delivery_context: 'standard',
+          recipient_id:     'adm_1',
+          recipient_type:   'Admin'
+        }
+      end
+    end
+
+    it 'calls the API to deliver an email' do
+      without_partial_double_verification do
+        expect(platform_client).to receive(:create_email_delivery).with(
+          have_attributes(id: 'prv_1'),
+          have_attributes(delivery_context: 'standard', recipient_id: 'adm_1', recipient_type: 'Admin')
         )
       end
 


### PR DESCRIPTION
As part of https://github.com/dbdrive/sicherungskasten/issues/1157 we will need to send emails to admins. To facilitate this, we changed the API to receive a more generic `recipient_id` and `recipient_type` over a `user_id` here (https://github.com/dbdrive/triebwerk/pull/20309). This brings ioki ruby back in line with that.