### PR TITLE
Operator Api | Batch delete vehicles

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -736,6 +736,19 @@ module Ioki
         path:        [API_BASE_PATH, 'products', :id, 'stations', 'batch_deletion_requests', :id],
         model_class: Ioki::Model::Operator::BatchDeletionRequest
       ),
+      Endpoints::Create.new(
+        :vehicle_batch_deletion_request,
+        base_path:            [API_BASE_PATH, 'products', :id, 'vehicles'],
+        path:                 'batch_deletion_requests',
+        model_class:          Ioki::Model::Operator::BatchDeletionRequest,
+        outgoing_model_class: Ioki::Model::Operator::VehicleBatch
+      ),
+      Endpoints::ShowSingular.new(
+        :vehicle_batch_deletion_request,
+        base_path:   nil,
+        path:        [API_BASE_PATH, 'products', :id, 'vehicles', 'batch_deletion_requests', :id],
+        model_class: Ioki::Model::Operator::BatchDeletionRequest
+      ),
       Endpoints.crud_endpoints(
         :purchase,
         base_path:   [API_BASE_PATH, 'providers', :id],

--- a/lib/ioki/model/operator/vehicle_batch.rb
+++ b/lib/ioki/model/operator/vehicle_batch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class VehicleBatch < Base
+        def self.schema_path
+          'operator_api--v20210101--vehicle_batch_archive_schema'
+        end
+
+        attribute :vehicle_ids,
+                  on:   :create,
+                  type: :array
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -3217,4 +3217,32 @@ RSpec.describe Ioki::OperatorApi do
       expect(operator_client.line_state('0815', options)).to be_a Ioki::Model::Operator::LineState
     end
   end
+
+  describe '#create_vehicle_batch_deletion_request(product_id)' do
+    let(:vehicle_batch) { Ioki::Model::Operator::VehicleBatch.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/vehicles/batch_deletion_requests')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_vehicle_batch_deletion_request(
+               '0815', vehicle_batch, options
+             )).to be_a(Ioki::Model::Operator::BatchDeletionRequest)
+    end
+  end
+
+  describe '#vehicle_batch_deletion_request(product_id, batch_deletion_request_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/vehicles/batch_deletion_requests/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.vehicle_batch_deletion_request('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces support for creating and retrieving batch deletion requests for vehicles in the Operator API. The changes include new API endpoints, a new model for vehicle batches, and corresponding tests to ensure correct behavior.