### PR TITLE
Operator Api | Batch delete lines

### DIFF
--- a/lib/ioki/apis/operator_api.rb
+++ b/lib/ioki/apis/operator_api.rb
@@ -763,6 +763,19 @@ module Ioki
         base_path:   [API_BASE_PATH, 'providers', :id],
         model_class: Ioki::Model::Operator::Purchase,
         only:        [:index, :show]
+      ),
+      Endpoints::Create.new(
+        :line_batch_deletion_request,
+        base_path:            [API_BASE_PATH, 'products', :id, 'lines'],
+        path:                 'batch_deletion_requests',
+        model_class:          Ioki::Model::Operator::BatchDeletionRequest,
+        outgoing_model_class: Ioki::Model::Operator::LineBatch
+      ),
+      Endpoints::ShowSingular.new(
+        :line_batch_deletion_request,
+        base_path:   nil,
+        path:        [API_BASE_PATH, 'products', :id, 'lines', 'batch_deletion_requests', :id],
+        model_class: Ioki::Model::Operator::BatchDeletionRequest
       )
     ].freeze
   end

--- a/lib/ioki/model/operator/line_batch.rb
+++ b/lib/ioki/model/operator/line_batch.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Operator
+      class LineBatch < Base
+        def self.schema_path
+          'operator_api--v20210101--line_batch_archive_schema'
+        end
+
+        attribute :line_ids,
+                  on:   :create,
+                  type: :array
+      end
+    end
+  end
+end

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -3286,9 +3286,8 @@ RSpec.describe Ioki::OperatorApi do
         [result_with_data, full_response]
       end
 
-      expect(operator_client.create_vehicle_batch_deletion_request(
-               '0815', vehicle_batch, options
-             )).to be_a(Ioki::Model::Operator::BatchDeletionRequest)
+      expect(operator_client.create_vehicle_batch_deletion_request('0815', vehicle_batch, options))
+        .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
     end
   end
 
@@ -3300,6 +3299,33 @@ RSpec.describe Ioki::OperatorApi do
       end
 
       expect(operator_client.vehicle_batch_deletion_request('0815', '4711', options))
+        .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
+    end
+  end
+
+  describe '#create_line_batch_deletion_request(product_id)' do
+    let(:line_batch) { Ioki::Model::Operator::LineBatch.new }
+
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/lines/batch_deletion_requests')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.create_line_batch_deletion_request('0815', line_batch, options))
+        .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
+    end
+  end
+
+  describe '#line_batch_deletion_request(product_id, batch_deletion_request_id)' do
+    it 'calls request on the client with expected params' do
+      expect(operator_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('operator/products/0815/lines/batch_deletion_requests/4711')
+        [result_with_data, full_response]
+      end
+
+      expect(operator_client.line_batch_deletion_request('0815', '4711', options))
         .to be_a(Ioki::Model::Operator::BatchDeletionRequest)
     end
   end


### PR DESCRIPTION
This pull request introduces support for batch deletion requests of lines in the Operator API. The main changes add new endpoints for creating and retrieving batch deletion requests, define a new model for line batches, and add corresponding tests to ensure correct behavior.