### PR TITLE
Fix receiver/recipient mixup

### DIFF
--- a/lib/ioki/mailing/mailer.rb
+++ b/lib/ioki/mailing/mailer.rb
@@ -30,7 +30,7 @@ module Ioki
         email_delivery = Ioki::Model::Platform::EmailDelivery.new(
           delivery_context: delivery_context,
           mime_message:     mail.encoded,
-          **recipient_options(mail.ioki_options)
+          **receiver_options(mail.ioki_options)
         )
 
         platform_client.create_email_delivery(provider, email_delivery)
@@ -44,11 +44,11 @@ module Ioki
         !!(options[:platform_client] && options[:provider_id])
       end
 
-      def recipient_options(options)
+      def receiver_options(options)
         if options[:user_id]
-          { recipient_id: options[:user_id], recipient_type: 'User' }
+          { receiver_id: options[:user_id], receiver_type: 'User' }
         else
-          { recipient_id: options[:recipient_id], recipient_type: options[:recipient_type] }
+          { receiver_id: options[:receiver_id], receiver_type: options[:receiver_type] }
         end
       end
     end

--- a/lib/ioki/model/platform/email_delivery.rb
+++ b/lib/ioki/model/platform/email_delivery.rb
@@ -9,13 +9,13 @@ module Ioki
         end
 
         attribute :delivery_context, on: :create, type: :string
-        attribute :recipient_id, on: :create, type: :string, omit_if_nil_on: :create
-        attribute :recipient_type, on: :create, type: :string, omit_if_nil_on: :create
+        attribute :receiver_id, on: :create, type: :string, omit_if_nil_on: :create
+        attribute :receiver_type, on: :create, type: :string, omit_if_nil_on: :create
         deprecated_attribute :user_id,
                              on:             :create,
                              type:           :string,
                              omit_if_nil_on: :create,
-                             replaced_by:    :recipient_id
+                             replaced_by:    :receiver_id
         attribute :mime_message, on: :create, type: :string
       end
     end

--- a/spec/ioki/mailing/mailer_spec.rb
+++ b/spec/ioki/mailing/mailer_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe Ioki::Mailing::Mailer do
           provider_id:      'prv_1',
           platform_client:  platform_client,
           delivery_context: 'standard',
-          receiver_id:     'adm_1',
-          receiver_type:   'Admin'
+          receiver_id:      'adm_1',
+          receiver_type:    'Admin'
         }
       end
     end

--- a/spec/ioki/mailing/mailer_spec.rb
+++ b/spec/ioki/mailing/mailer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Ioki::Mailing::Mailer do
       without_partial_double_verification do
         expect(platform_client).to receive(:create_email_delivery).with(
           have_attributes(id: 'prv_1'),
-          have_attributes(delivery_context: 'registration', recipient_id: nil, recipient_type: nil)
+          have_attributes(delivery_context: 'registration', receiver_id: nil, receiver_type: nil)
         )
       end
 
@@ -50,7 +50,7 @@ RSpec.describe Ioki::Mailing::Mailer do
       without_partial_double_verification do
         expect(platform_client).to receive(:create_email_delivery).with(
           have_attributes(id: 'prv_1'),
-          have_attributes(delivery_context: 'standard', recipient_id: 'usr_1', recipient_type: 'User')
+          have_attributes(delivery_context: 'standard', receiver_id: 'usr_1', receiver_type: 'User')
         )
       end
 
@@ -58,15 +58,15 @@ RSpec.describe Ioki::Mailing::Mailer do
     end
   end
 
-  context 'with recipient_id and recipient_type' do
+  context 'with receiver_id and receiver_type' do
     let(:mail) do
       Mail::Message.new.tap do |message|
         message.ioki_options = {
           provider_id:      'prv_1',
           platform_client:  platform_client,
           delivery_context: 'standard',
-          recipient_id:     'adm_1',
-          recipient_type:   'Admin'
+          receiver_id:     'adm_1',
+          receiver_type:   'Admin'
         }
       end
     end
@@ -75,7 +75,7 @@ RSpec.describe Ioki::Mailing::Mailer do
       without_partial_double_verification do
         expect(platform_client).to receive(:create_email_delivery).with(
           have_attributes(id: 'prv_1'),
-          have_attributes(delivery_context: 'standard', recipient_id: 'adm_1', recipient_type: 'Admin')
+          have_attributes(delivery_context: 'standard', receiver_id: 'adm_1', receiver_type: 'Admin')
         )
       end
 


### PR DESCRIPTION
I mixed up the naming because the fields are `receiver_id` and `receiver_type`, but the constraint is called `required_recipient_id`...