### PR TITLE
Operator | Add missing attributes to `RideOption` model

### DIFF
--- a/lib/ioki/model/operator/ride_option.rb
+++ b/lib/ioki/model/operator/ride_option.rb
@@ -100,6 +100,14 @@ module Ioki
                   on:         [:read, :create, :update],
                   type:       :object,
                   class_name: 'ResourceConfiguration'
+
+        attribute :reporting_column_index,
+                  on:   [:read, :create, :update],
+                  type: :integer
+
+        attribute :reporting_column_name,
+                  on:   :read,
+                  type: :string
       end
     end
   end


### PR DESCRIPTION
I forgot to add these attributes when doing this PR https://github.com/ioki-mobility/ioki-ruby/pull/740. This PR will add the missing attributes.