### PR TITLE
Operator + Platform | Vehicle range budget attributes

### DIFF
--- a/lib/ioki/model/operator/vehicle.rb
+++ b/lib/ioki/model/operator/vehicle.rb
@@ -138,6 +138,24 @@ module Ioki
         attribute :driver_missing,
                   on:   :read,
                   type: :boolean
+
+        attribute :maximum_range_budget,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :current_range_budget,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :range_budget_unit,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :range_budget_calculation_adapter_name,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
       end
     end
   end

--- a/lib/ioki/model/platform/vehicle.rb
+++ b/lib/ioki/model/platform/vehicle.rb
@@ -87,6 +87,24 @@ module Ioki
                   on:         :read,
                   type:       :object,
                   class_name: 'Telemetry'
+
+        attribute :maximum_range_budget,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :current_range_budget,
+                  on:   [:create, :read, :update],
+                  type: :integer
+
+        attribute :range_budget_unit,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
+
+        attribute :range_budget_calculation_adapter_name,
+                  on:             [:create, :read, :update],
+                  omit_if_nil_on: [:create, :update],
+                  type:           :string
       end
     end
   end


### PR DESCRIPTION
This pull request adds new attributes related to vehicle range budget management to both the operator and platform `Vehicle` models. These changes enable the system to handle information about a vehicle’s range budget, including its maximum and current values, unit, and the calculation method.

**Vehicle Range Budget Enhancements:**

* Added `maximum_range_budget` and `current_range_budget` integer attributes to the `Vehicle` model, available for create, read, and update operations. [[1]](diffhunk://#diff-7d7d1baf9cb0a98f334bfcf4e2697847692faf3b4dbec2df14c15852cccbb030R141-R158) [[2]](diffhunk://#diff-13ee028cd165b10f1c23100d68cc7f6109140ec07e5bfbc7be3b873d10ff06d6R90-R107)
* Introduced `range_budget_unit` and `range_budget_calculation_adapter_name` string attributes to the `Vehicle` model, also available for create, read, and update operations, with logic to omit them if nil during create and update. [[1]](diffhunk://#diff-7d7d1baf9cb0a98f334bfcf4e2697847692faf3b4dbec2df14c15852cccbb030R141-R158) [[2]](diffhunk://#diff-13ee028cd165b10f1c23100d68cc7f6109140ec07e5bfbc7be3b873d10ff06d6R90-R107)