### PR TITLE
Fix exception caused when marshalling models

### DIFF
--- a/lib/ioki.rb
+++ b/lib/ioki.rb
@@ -34,5 +34,13 @@ module Ioki
     def configure
       yield(config)
     end
+
+    def deprecator
+      @deprecator ||= if defined?(Rails)
+                        ActiveSupport::Deprecation.new('1.0', 'Ioki')
+                      else
+                        Kernel
+                      end
+    end
   end
 end

--- a/lib/ioki/model/base.rb
+++ b/lib/ioki/model/base.rb
@@ -340,15 +340,7 @@ module Ioki
       end
 
       def deprecation_warning(message)
-        if defined?(Rails)
-          deprecator.warn(message)
-        else
-          warn message
-        end
-      end
-
-      def deprecator
-        @deprecator ||= ActiveSupport::Deprecation.new('1.0', 'Ioki')
+        Ioki.deprecator.warn(message)
       end
     end
   end

--- a/lib/ioki/railtie.rb
+++ b/lib/ioki/railtie.rb
@@ -8,5 +8,9 @@ module Ioki
     ActiveSupport.on_load(:action_mailer) do
       add_delivery_method :ioki, Ioki::Mailing::Mailer
     end
+
+    initializer 'ioki.deprecator' do |app|
+      app.deprecators[:ioki] = Ioki.deprecator
+    end
   end
 end


### PR DESCRIPTION
Fixes exception: `no _dump_data is defined for class Proc`

Occurs when `Ioki` models are involved in caching, and therefore marshalled. Until now we created the deprecator on every model, but it should in fact live on the gem module instead.

For non-Rails projects, we use `Kernel` as a deprecator. We only call `warn` on the deprecator, which also exists on `Kernel`.