### PR TITLE
Operator API | Add `default_values` and `fixed_values` to filters

### DIFF
--- a/lib/ioki/model/operator/reporting/report_aggregation_filter.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_filter.rb
@@ -24,6 +24,14 @@ module Ioki
           attribute :localized_values,
                     on:   :read,
                     type: :array
+
+          attribute :default_values,
+                    on:   :read,
+                    type: :array
+
+          attribute :fixed_values,
+                    on:   :read,
+                    type: :array
         end
       end
     end

--- a/spec/ioki/model/operator/reporting/report_aggregation_filter_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_filter_spec.rb
@@ -18,12 +18,16 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationFilter do
   it { is_expected.to define_attribute(:localized_name).as(:string) }
   it { is_expected.to define_attribute(:values).as(:array) }
   it { is_expected.to define_attribute(:localized_values).as(:array) }
+  it { is_expected.to define_attribute(:default_values).as(:array) }
+  it { is_expected.to define_attribute(:fixed_values).as(:array) }
 
   it 'casts filter metadata' do
     expect(filter.name).to eq('operator_id')
     expect(filter.localized_name).to eq('Operator')
     expect(filter.values).to eq(%w[op-1 op-2])
     expect(filter.localized_values).to eq(%w[Op-1 Op-2])
+    expect(filter.default_values).to be_nil
+    expect(filter.fixed_values).to be_nil
   end
 
   it 'accepts unrestricted filter values' do


### PR DESCRIPTION
Adds two new optional attributes to the filters in the aggregation model.