### PR TITLE
Operator API | Add `Item#has_aggregations`

### DIFF
--- a/lib/ioki/model/operator/reporting/report_navigation/item.rb
+++ b/lib/ioki/model/operator/reporting/report_navigation/item.rb
@@ -21,6 +21,10 @@ module Ioki
             attribute :description,
                       on:   :read,
                       type: :string
+
+            attribute :has_aggregations,
+                      on:   :read,
+                      type: :boolean
           end
         end
       end


### PR DESCRIPTION
Adds `has_aggregations` to the reporting navigation items.