### PR TITLE
Operator API | Add measure description

### DIFF
--- a/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
@@ -17,6 +17,10 @@ module Ioki
                     on:   :read,
                     type: :string
 
+          attribute :localized_description,
+                    on:   :read,
+                    type: :string
+
           attribute :function,
                     on:   :read,
                     type: :string

--- a/lib/ioki/model/operator/reporting/report_aggregation_measure_series.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_measure_series.rb
@@ -17,6 +17,10 @@ module Ioki
                     on:   :read,
                     type: :string
 
+          attribute :localized_measure_description,
+                    on:   :read,
+                    type: :string
+
           attribute :dimension_name,
                     on:   :read,
                     type: :string


### PR DESCRIPTION
Adds two attributes containing a measure description.