### PR TITLE
Operator API | Add `format_type` and `format_unit`

### DIFF
--- a/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
+++ b/lib/ioki/model/operator/reporting/report_aggregation_measure.rb
@@ -25,19 +25,27 @@ module Ioki
                     on:   :read,
                     type: :string
 
-          attribute :percentile,
-                    on:   :read,
-                    type: :float
-
           attribute :localized_function,
                     on:   :read,
                     type: :string
 
-          attribute :measure_type,
+          attribute :percentile,
+                    on:   :read,
+                    type: :float
+
+          attribute :format_type,
                     on:   :read,
                     type: :string
 
-          attribute :localized_measure_type,
+          attribute :localized_format_type,
+                    on:   :read,
+                    type: :string
+
+          attribute :format_unit,
+                    on:   :read,
+                    type: :string
+
+          attribute :localized_format_unit,
                     on:   :read,
                     type: :string
         end

--- a/spec/ioki/model/operator/reporting/report_aggregation_measure_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_measure_spec.rb
@@ -5,14 +5,12 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationMeasure do
 
   let(:attributes) do
     {
-      type:                   'reporting/report_aggregation_measure',
-      name:                   'login_count',
-      localized_name:         'Logins',
-      function:               'count_rows',
-      percentile:             nil,
-      localized_function:     'Count',
-      measure_type:           'number',
-      localized_measure_type: 'Count'
+      type:               'reporting/report_aggregation_measure',
+      name:               'login_count',
+      localized_name:     'Logins',
+      function:           'count_rows',
+      percentile:         nil,
+      localized_function: 'Count'
     }
   end
 
@@ -22,8 +20,10 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationMeasure do
   it { is_expected.to define_attribute(:function).as(:string) }
   it { is_expected.to define_attribute(:percentile).as(:float) }
   it { is_expected.to define_attribute(:localized_function).as(:string) }
-  it { is_expected.to define_attribute(:measure_type).as(:string) }
-  it { is_expected.to define_attribute(:localized_measure_type).as(:string) }
+  it { is_expected.to define_attribute(:format_type).as(:string) }
+  it { is_expected.to define_attribute(:localized_format_type).as(:string) }
+  it { is_expected.to define_attribute(:format_unit).as(:string) }
+  it { is_expected.to define_attribute(:localized_format_unit).as(:string) }
 
   it 'casts measure metadata' do
     expect(measure.name).to eq('login_count')
@@ -31,8 +31,6 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregationMeasure do
     expect(measure.function).to eq('count_rows')
     expect(measure.percentile).to be_nil
     expect(measure.localized_function).to eq('Count')
-    expect(measure.measure_type).to eq('number')
-    expect(measure.localized_measure_type).to eq('Count')
   end
 
   it 'casts percentile values for percentile measures' do

--- a/spec/ioki/model/operator/reporting/report_aggregation_spec.rb
+++ b/spec/ioki/model/operator/reporting/report_aggregation_spec.rb
@@ -21,14 +21,12 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregation do
       },
       measures:                [
         {
-          type:                   'reporting/report_aggregation_measure',
-          name:                   'rides',
-          localized_name:         'Rides',
-          function:               'count_rows',
-          percentile:             nil,
-          localized_function:     'Count',
-          measure_type:           'number',
-          localized_measure_type: 'Count'
+          type:               'reporting/report_aggregation_measure',
+          name:               'rides',
+          localized_name:     'Rides',
+          function:           'count_rows',
+          percentile:         nil,
+          localized_function: 'Count'
         }
       ],
       dimensions:              [
@@ -75,7 +73,6 @@ RSpec.describe Ioki::Model::Operator::Reporting::ReportAggregation do
     expect(report_aggregation.measures.first).to be_a(
       Ioki::Model::Operator::Reporting::ReportAggregationMeasure
     )
-    expect(report_aggregation.measures.first.measure_type).to eq('number')
     expect(report_aggregation.measures.first.percentile).to be_nil
     expect(report_aggregation.measures.first.localized_name).to eq('Rides')
     expect(report_aggregation.dimensions.first).to be_a(

--- a/spec/ioki/operator_api_spec.rb
+++ b/spec/ioki/operator_api_spec.rb
@@ -1942,14 +1942,12 @@ RSpec.describe Ioki::OperatorApi do
             },
             measures:                [
               {
-                type:                   'reporting/report_aggregation_measure',
-                name:                   'login_count',
-                localized_name:         'Logins',
-                function:               'count_rows',
-                percentile:             nil,
-                localized_function:     'Count',
-                measure_type:           'number',
-                localized_measure_type: 'Count'
+                type:               'reporting/report_aggregation_measure',
+                name:               'login_count',
+                localized_name:     'Logins',
+                function:           'count_rows',
+                percentile:         nil,
+                localized_function: 'Count'
               }
             ],
             dimensions:              [],


### PR DESCRIPTION
Adds two attributes to aggregation measures and removes the deprecated `measure_type`.