### PR TITLE
Add `claimed` to platform API user

### DIFF
--- a/lib/ioki/model/platform/user.rb
+++ b/lib/ioki/model/platform/user.rb
@@ -9,6 +9,7 @@ module Ioki
         attribute :created_at, on: :read, type: :date_time
         attribute :updated_at, on: :read, type: :date_time
         attribute :analytics_tracking, on: [:read, :create], type: :boolean
+        attribute :claimed, on: [:read, :create], type: :boolean
         attribute :email,
                   type:             :object,
                   on:               [:read, :create, :update],

--- a/lib/ioki/model/platform/user.rb
+++ b/lib/ioki/model/platform/user.rb
@@ -9,7 +9,7 @@ module Ioki
         attribute :created_at, on: :read, type: :date_time
         attribute :updated_at, on: :read, type: :date_time
         attribute :analytics_tracking, on: [:read, :create], type: :boolean
-        attribute :claimed, on: [:read, :create], type: :boolean
+        attribute :claimed, on: [:create], type: :boolean
         attribute :email,
                   type:             :object,
                   on:               [:read, :create, :update],

--- a/spec/ioki/model/platform/user_spec.rb
+++ b/spec/ioki/model/platform/user_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Ioki::Model::Platform::User do
   it { is_expected.to define_attribute(:created_at).as(:date_time) }
   it { is_expected.to define_attribute(:updated_at).as(:date_time) }
 
+  it { is_expected.to define_attribute(:claimed).as(:boolean) }
   it { is_expected.to define_attribute(:email).as(:object).with(class_name: 'UserEmail') }
   it { is_expected.to define_attribute(:external_id).as(:string) }
   it { is_expected.to define_attribute(:first_name).as(:string) }


### PR DESCRIPTION
This is needed in order to make https://github.com/dbdrive/sprachrohr/pull/47 work.

### Contents

Lets clients create unclaimed users via the Platform API. The attribute is accepted on create. I confirmed that the triebwerk platform api schemata support the attribute.

It is not returned on read since the serializer does not expose it.