### PR TITLE
Add geocoding endpoints to Passenger API

### DIFF
--- a/lib/ioki/apis/passenger_api.rb
+++ b/lib/ioki/apis/passenger_api.rb
@@ -265,6 +265,31 @@ module Ioki
         path:                 'purchase',
         model_class:          Ioki::Model::Passenger::Ticketing::Voucher,
         outgoing_model_class: Ioki::Model::Passenger::Ticketing::ProductPurchase
+      ),
+      Endpoints::Create.new(
+        :geocoding_session,
+        base_path:   [API_BASE_PATH, 'geocoding'],
+        path:        'session',
+        model_class: Ioki::Model::Passenger::GeocodingSession
+      ),
+      Endpoints::Delete.new(
+        :geocoding_session,
+        base_path:   [API_BASE_PATH, 'geocoding'],
+        path:        'session',
+        model_class: nil
+      ),
+      Endpoints::Create.new(
+        :geocoding_search,
+        base_path:            [API_BASE_PATH, 'geocoding', 'session', :id],
+        path:                 'search',
+        model_class:          Ioki::Model::Passenger::GeocodingSearchResults,
+        outgoing_model_class: Ioki::Model::Passenger::GeocodingSearch
+      ),
+      Endpoints::Create.new(
+        :geocoding_search_details,
+        base_path:   [API_BASE_PATH, 'geocoding', 'session', :id],
+        path:        'details',
+        model_class: Ioki::Model::Passenger::GeocodingSearchDetails
       )
     ].freeze
   end

--- a/lib/ioki/model/passenger/geocoding_search.rb
+++ b/lib/ioki/model/passenger/geocoding_search.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class GeocodingSearch < Base
+        attribute :query,
+                  on:   :create,
+                  type: :string
+
+        attribute :product_id,
+                  on:   :create,
+                  type: :string
+
+        attribute :place_types,
+                  on:   :create,
+                  type: :string
+
+        attribute :result_types,
+                  on:   :create,
+                  type: :array
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/geocoding_search.rb
+++ b/lib/ioki/model/passenger/geocoding_search.rb
@@ -12,10 +12,6 @@ module Ioki
                   on:   :create,
                   type: :string
 
-        attribute :place_types,
-                  on:   :create,
-                  type: :string
-
         attribute :result_types,
                   on:   :create,
                   type: :array

--- a/lib/ioki/model/passenger/geocoding_search_details.rb
+++ b/lib/ioki/model/passenger/geocoding_search_details.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class GeocodingSearchDetails < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :create,
+                  type: :string
+
+        attribute :vendor_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor_type,
+                  on:   :read,
+                  type: :string
+
+        attribute :location_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :formatted_address,
+                  on:   :read,
+                  type: :string
+
+        attribute :street_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :street_number,
+                  on:   :read,
+                  type: :string
+
+        attribute :postal_code,
+                  on:   :read,
+                  type: :string
+
+        attribute :city,
+                  on:   :read,
+                  type: :string
+
+        attribute :county,
+                  on:   :read,
+                  type: :string
+
+        attribute :country,
+                  on:   :read,
+                  type: :string
+
+        attribute :lat,
+                  on:   :read,
+                  type: :float
+
+        attribute :lng,
+                  on:   :read,
+                  type: :float
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/geocoding_search_result.rb
+++ b/lib/ioki/model/passenger/geocoding_search_result.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class GeocodingSearchResult < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor_id,
+                  on:   :read,
+                  type: :string
+
+        attribute :vendor,
+                  on:   :read,
+                  type: :string
+
+        attribute :formatted_address,
+                  on:   :read,
+                  type: :string
+
+        attribute :description,
+                  on:   :read,
+                  type: :string
+
+        attribute :location_name,
+                  on:   :read,
+                  type: :string
+
+        attribute :lat,
+                  on:   :read,
+                  type: :float
+
+        attribute :lng,
+                  on:   :read,
+                  type: :float
+
+        attribute :result_type,
+                  on:   :read,
+                  type: :string
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/geocoding_search_results.rb
+++ b/lib/ioki/model/passenger/geocoding_search_results.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class GeocodingSearchResults < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :results,
+                  on:         :read,
+                  type:       :array,
+                  class_name: 'Ioki::Model::Passenger::GeocodingSearchResult'
+      end
+    end
+  end
+end

--- a/lib/ioki/model/passenger/geocoding_session.rb
+++ b/lib/ioki/model/passenger/geocoding_session.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Ioki
+  module Model
+    module Passenger
+      class GeocodingSession < Base
+        attribute :type,
+                  on:   :read,
+                  type: :string
+
+        attribute :id,
+                  on:   :read,
+                  type: :string
+
+        attribute :created_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :updated_at,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :valid_until,
+                  on:   :read,
+                  type: :date_time
+
+        attribute :product_id,
+                  on:   :create,
+                  type: :string
+      end
+    end
+  end
+end

--- a/spec/ioki/model/passenger/geocoding_search_details_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_search_details_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Passenger::GeocodingSearchDetails do
+  it { is_expected.to define_attribute(:type).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:id).as(:string).with(on: :create) }
+  it { is_expected.to define_attribute(:vendor_id).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:vendor).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:vendor_type).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:location_name).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:formatted_address).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:street_name).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:street_number).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:postal_code).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:city).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:county).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:country).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:lat).as(:float).with(on: :read) }
+  it { is_expected.to define_attribute(:lng).as(:float).with(on: :read) }
+end

--- a/spec/ioki/model/passenger/geocoding_search_result_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_search_result_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Passenger::GeocodingSearchResult do
+  it { is_expected.to define_attribute(:type).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:id).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:vendor_id).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:vendor).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:formatted_address).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:description).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:location_name).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:lat).as(:float).with(on: :read) }
+  it { is_expected.to define_attribute(:lng).as(:float).with(on: :read) }
+  it { is_expected.to define_attribute(:result_type).as(:string).with(on: :read) }
+end

--- a/spec/ioki/model/passenger/geocoding_search_results_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_search_results_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Passenger::GeocodingSearchResults do
+  it { is_expected.to define_attribute(:type).as(:string).with(on: :read) }
+
+  it do
+    is_expected.to define_attribute(:results)
+      .as(:array)
+      .with(on: :read, class_name: 'Ioki::Model::Passenger::GeocodingSearchResult')
+  end
+end

--- a/spec/ioki/model/passenger/geocoding_search_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_search_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Passenger::GeocodingSearch do
+  it { is_expected.to define_attribute(:query).as(:string).with(on: :create) }
+  it { is_expected.to define_attribute(:product_id).as(:string).with(on: :create) }
+  it { is_expected.to define_attribute(:place_types).as(:string).with(on: :create) }
+  it { is_expected.to define_attribute(:result_types).as(:array).with(on: :create) }
+end

--- a/spec/ioki/model/passenger/geocoding_search_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_search_spec.rb
@@ -3,6 +3,5 @@
 RSpec.describe Ioki::Model::Passenger::GeocodingSearch do
   it { is_expected.to define_attribute(:query).as(:string).with(on: :create) }
   it { is_expected.to define_attribute(:product_id).as(:string).with(on: :create) }
-  it { is_expected.to define_attribute(:place_types).as(:string).with(on: :create) }
   it { is_expected.to define_attribute(:result_types).as(:array).with(on: :create) }
 end

--- a/spec/ioki/model/passenger/geocoding_session_spec.rb
+++ b/spec/ioki/model/passenger/geocoding_session_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Ioki::Model::Passenger::GeocodingSession do
+  it { is_expected.to define_attribute(:type).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:id).as(:string).with(on: :read) }
+  it { is_expected.to define_attribute(:created_at).as(:date_time).with(on: :read) }
+  it { is_expected.to define_attribute(:updated_at).as(:date_time).with(on: :read) }
+  it { is_expected.to define_attribute(:valid_until).as(:date_time).with(on: :read) }
+
+  it { is_expected.to define_attribute(:product_id).as(:string).with(on: :create) }
+end

--- a/spec/ioki/passenger_api_spec.rb
+++ b/spec/ioki/passenger_api_spec.rb
@@ -637,4 +637,62 @@ RSpec.describe Ioki::PassengerApi do
         .to be_a Ioki::Model::Passenger::Ticketing::Voucher
     end
   end
+
+  describe '#create_geocoding_session()' do
+    let(:geocoding_session) { Ioki::Model::Passenger::GeocodingSession.new }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/geocoding/session')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_geocoding_session(geocoding_session, options))
+        .to be_a(Ioki::Model::Passenger::GeocodingSession)
+    end
+  end
+
+  describe '#delete_geocoding_session(id)' do
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/geocoding/session/0815')
+        expect(params[:method]).to eq(:delete)
+        result_with_data
+      end
+
+      expect(passenger_client.delete_geocoding_session('0815', options))
+        .to be_nil
+    end
+  end
+
+  describe '#create_geocoding_search(id)' do
+    let(:geocoding_search) { Ioki::Model::Passenger::GeocodingSearch.new }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/geocoding/session/0815/search')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_geocoding_search('0815', geocoding_search, options))
+        .to be_a(Ioki::Model::Passenger::GeocodingSearchResults)
+    end
+  end
+
+  describe '#create_geocoding_search_details(id)' do
+    let(:geocoding_search_details) { Ioki::Model::Passenger::GeocodingSearchDetails.new }
+
+    it 'calls request on the client with expected params' do
+      expect(passenger_client).to receive(:request) do |params|
+        expect(params[:url].to_s).to eq('passenger/geocoding/session/0815/details')
+        expect(params[:method]).to eq(:post)
+        [result_with_data, full_response]
+      end
+
+      expect(passenger_client.create_geocoding_search_details('0815', geocoding_search_details, options))
+        .to be_a(Ioki::Model::Passenger::GeocodingSearchDetails)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
  Adds the passenger-API geocoding session/search/details endpoints and their models to the gem, mirroring the existing operator geocoding implementation

  ## Contents
  - **Endpoints**: `create_geocoding_session`, `delete_geocoding_session`, `create_geocoding_search`,
  `create_geocoding_search_details`
  - **Models**: `GeocodingSession` (create takes `product_id` only — the user
  comes from the request-token auth), `GeocodingSearch`, `GeocodingSearchResults`, `GeocodingSearchResult`, `GeocodingSearchDetails`.