### PR TITLE
Passenger/Platform API | Remove `payment_method_required_on_booking`

### DIFF
--- a/lib/ioki/model/passenger/product.rb
+++ b/lib/ioki/model/passenger/product.rb
@@ -20,7 +20,6 @@ module Ioki
         attribute :description, on: :read, type: :string
         attribute :fixed_stations, on: :read, type: :array, class_name: 'Station'
         attribute :payment_method_allowed_on_booking, on: :read, type: :boolean
-        attribute :payment_method_required_on_booking, on: :read, type: :boolean
         attribute :personal_discount_types, on: :read, type: :array, class_name: 'PersonalDiscountType'
         attribute :phone_number, on: :read, type: :string
         attribute :prebookable, on: :read, type: :boolean

--- a/lib/ioki/model/platform/product.rb
+++ b/lib/ioki/model/platform/product.rb
@@ -19,7 +19,6 @@ module Ioki
         attribute :help_url, on: :read, type: :string
         attribute :name, on: :read, type: :string
         attribute :payment_method_allowed_on_booking, on: :read, type: :boolean
-        attribute :payment_method_required_on_booking, on: :read, type: :boolean
         attribute :prebookable, on: :read, type: :boolean
         attribute :ride_options, on: :read, type: :object, class_name: 'RideOptions'
         attribute :ride_rating_criteria, on: :read, type: :array


### PR DESCRIPTION
Breaking change: The API removes that attribute, so it will not be included in API responses anymore.