### PR TITLE
Add verified/unverified phone number to platform API user

### DIFF
--- a/lib/ioki/model/platform/user.rb
+++ b/lib/ioki/model/platform/user.rb
@@ -24,6 +24,8 @@ module Ioki
         attribute :locked_at, type: :date_time, on: :read
         attribute :minimum_age_confirmed, on: [:read, :create], type: :boolean
         attribute :phone_number, type: :string, on: [:read, :create, :update], omit_if_blank_on: [:create, :update]
+        attribute :verified_phone_number, type: :string, on: [:create, :update], omit_if_blank_on: [:create, :update]
+        attribute :unverified_phone_number, type: :string, on: [:create, :update], omit_if_blank_on: [:create, :update]
         attribute :provider_id, type: :string, on: :read
         attribute :terms_accepted, type: :boolean, on: [:create, :update], unvalidated: true
         attribute :terms_accepted_at, type: :date_time, on: :read

--- a/spec/ioki/model/platform/user_spec.rb
+++ b/spec/ioki/model/platform/user_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Ioki::Model::Platform::User do
   it { is_expected.to define_attribute(:lock_type).as(:string) }
   it { is_expected.to define_attribute(:locked_at).as(:date_time) }
   it { is_expected.to define_attribute(:phone_number).as(:string) }
+  it { is_expected.to define_attribute(:verified_phone_number).as(:string) }
+  it { is_expected.to define_attribute(:unverified_phone_number).as(:string) }
   it { is_expected.to define_attribute(:provider_id).as(:string).with(on: :read) }
   it { is_expected.to define_attribute(:terms_accepted_at).as(:date_time) }
   it { is_expected.to define_attribute(:terms_accepted).as(:boolean) }


### PR DESCRIPTION
The phone_number attribute is deprecated in the Platform API user schema. The create and update schemas expose `verified_phone_number` and `unverified_phone_number` instead. Add both as write-only create/update attributes.