### PR TITLE
Rides | `available_payment_method_types`

### DIFF
--- a/lib/ioki/model/operator/provider.rb
+++ b/lib/ioki/model/operator/provider.rb
@@ -75,9 +75,9 @@ module Ioki
                   on:   :read,
                   type: :string
 
-        attribute :ride_payment_method_types,
-                  on:   :read,
-                  type: :array
+        deprecated_attribute :ride_payment_method_types,
+                             on:   :read,
+                             type: :array
 
         attribute :service_credit_options,
                   on:         :read,

--- a/lib/ioki/model/operator/ride.rb
+++ b/lib/ioki/model/operator/ride.rb
@@ -24,6 +24,10 @@ module Ioki
                   on:   :read,
                   type: :integer
 
+        attribute :available_payment_method_types,
+                  on:   :read,
+                  type: :array
+
         attribute :book_for_others,
                   on:   :read,
                   type: :boolean

--- a/lib/ioki/model/passenger/provider.rb
+++ b/lib/ioki/model/passenger/provider.rb
@@ -22,7 +22,7 @@ module Ioki
         attribute :postal_code, on: :read, type: :string
         attribute :psp, on: :read, type: :string
         attribute :retry_payment_method_types, on: :read, type: :array
-        attribute :ride_payment_method_types, on: :read, type: :array
+        deprecated_attribute :ride_payment_method_types, on: :read, type: :array
         attribute :service_credit_options, on: :read, type: :object, class_name: 'ServiceCreditOptions'
         attribute :service_credit_payment_method_types, on: :read, type: :array
         attribute :street_name, on: :read, type: :string

--- a/lib/ioki/model/passenger/ride.rb
+++ b/lib/ioki/model/passenger/ride.rb
@@ -8,6 +8,7 @@ module Ioki
         attribute :id, on: :read, type: :string
         attribute :created_at, on: :read, type: :date_time
         attribute :updated_at, on: :read, type: :date_time
+        attribute :available_payment_method_types, on: :read, type: :array
         attribute :origin, type: :object, on: [:create, :read], class_name: 'RequestedPoint'
         attribute :destination, type: :object, on: [:create, :read], class_name: 'RequestedPoint'
         attribute :passengers, type: :array, on: [:create, :read], class_name: 'RidePassenger'

--- a/lib/ioki/model/platform/provider.rb
+++ b/lib/ioki/model/platform/provider.rb
@@ -84,9 +84,9 @@ module Ioki
                   on:   :read,
                   type: :string
 
-        attribute :ride_payment_method_types,
-                  on:   :read,
-                  type: :array
+        deprecated_attribute :ride_payment_method_types,
+                             on:   :read,
+                             type: :array
 
         attribute :service_credit_payment_method_types,
                   on:   :read,

--- a/lib/ioki/model/platform/ride.rb
+++ b/lib/ioki/model/platform/ride.rb
@@ -8,6 +8,7 @@ module Ioki
         attribute :id, on: :read, type: :string
         attribute :created_at, on: :read, type: :date_time
         attribute :updated_at, on: :read, type: :date_time
+        attribute :available_payment_method_types, on: :read, type: :array
         attribute :book_for_others, on: [:read, :create, :update], type: :boolean
         attribute :booking, type: :object, on: :read, class_name: 'Booking'
         attribute :cancellable, on: :read, type: :boolean

--- a/spec/ioki/model/operator/ride_spec.rb
+++ b/spec/ioki/model/operator/ride_spec.rb
@@ -62,4 +62,5 @@ RSpec.describe Ioki::Model::Operator::Ride do
   it { is_expected.to define_attribute(:vehicle_reached_pickup_at).as(:date_time) }
   it { is_expected.to define_attribute(:last_serving_driver_id).as(:string) }
   it { is_expected.to define_attribute(:last_serving_driver).as(:object).with(class_name: 'Driver') }
+  it { is_expected.to define_attribute(:available_payment_method_types).as(:array) }
 end


### PR DESCRIPTION
The payment method types for rides now live on the ride directly, instead of being read from the provider.